### PR TITLE
remove unnecessary imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An intuitive way to work with persistent data in Dart.
 
-## [Full documentation](https://greenbits.github.io/brick/)
+## [Full documentation](https://getdutchie.github.io/brick/)
 
 ## Why Brick?
 

--- a/example/lib/app/models/pizza.dart
+++ b/example/lib/app/models/pizza.dart
@@ -1,5 +1,4 @@
 import 'package:brick_offline_first/offline_first_with_rest.dart';
-import 'package:brick_offline_first/offline_first.dart';
 
 @ConnectOfflineFirstWithRest(
   restConfig: RestSerializable(

--- a/packages/brick_build/README.md
+++ b/packages/brick_build/README.md
@@ -596,8 +596,6 @@ import 'dart:convert';
 import 'package:brick_sqlite/sqlite.dart' show SqliteModel, SqliteAdapter, SqliteModelDictionary;
 import 'package:brick_rest/rest.dart' show RestProvider, RestModel, RestAdapter, RestModelDictionary;
 // ignore: unused_import, unused_shown_name
-import 'package:brick_core/core.dart' show Query, QueryAction;
-// ignore: unused_import, unused_shown_name
 import 'package:sqflite/sqflite.dart' show DatabaseExecutor;
 """;
 ```

--- a/packages/brick_build/test/provider_serializable_generator_test.dart
+++ b/packages/brick_build/test/provider_serializable_generator_test.dart
@@ -1,7 +1,6 @@
 import 'package:brick_build/generators.dart';
 import 'package:source_gen/source_gen.dart';
 import 'package:test/test.dart';
-import 'package:brick_build_test/brick_build_test.dart';
 
 import '__helpers__.dart';
 

--- a/packages/brick_offline_first/example/lib/app/brick.g.dart
+++ b/packages/brick_offline_first/example/lib/app/brick.g.dart
@@ -14,8 +14,6 @@ import 'dart:convert';
 import 'package:brick_sqlite/sqlite.dart' show SqliteModel, SqliteAdapter, SqliteModelDictionary, RuntimeSqliteColumnDefinition;
 import 'package:brick_rest/rest.dart' show RestProvider, RestModel, RestAdapter, RestModelDictionary;
 // ignore: unused_import, unused_shown_name
-import 'package:brick_core/core.dart' show Query, QueryAction;
-// ignore: unused_import, unused_shown_name
 import 'package:sqflite/sqflite.dart' show DatabaseExecutor;
 
 import 'models/horse.dart';

--- a/packages/brick_offline_first/example/lib/app/db/schema.g.dart
+++ b/packages/brick_offline_first/example/lib/app/db/schema.g.dart
@@ -1,8 +1,6 @@
 // GENERATED CODE DO NOT EDIT
 // This file should be version controlled
 import 'package:brick_sqlite_abstract/db.dart';
-// ignore: unused_import
-import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 part '20200616220821.migration.dart';
 part '20210111041540.migration.dart';
 part '20200106215014.migration.dart';

--- a/packages/brick_offline_first/example/lib/app/models/horse.dart
+++ b/packages/brick_offline_first/example/lib/app/models/horse.dart
@@ -1,5 +1,4 @@
 import 'package:brick_offline_first/offline_first_with_rest.dart';
-import 'package:brick_offline_first_abstract/annotations.dart';
 
 import 'package:brick_offline_first_example/app/models/mounty.dart';
 

--- a/packages/brick_offline_first/example/lib/app/models/kitchen_sink.dart
+++ b/packages/brick_offline_first/example/lib/app/models/kitchen_sink.dart
@@ -1,5 +1,4 @@
 import 'package:brick_offline_first/offline_first_with_rest.dart';
-import 'package:brick_offline_first_abstract/annotations.dart';
 
 import 'package:brick_offline_first_example/app/models/hat.dart';
 import 'package:brick_offline_first_example/app/models/mounty.dart';

--- a/packages/brick_offline_first/example/lib/app/models/mounty.dart
+++ b/packages/brick_offline_first/example/lib/app/models/mounty.dart
@@ -1,5 +1,4 @@
 import 'package:brick_offline_first/offline_first_with_rest.dart';
-import 'package:brick_offline_first_abstract/annotations.dart';
 
 import 'package:brick_offline_first_example/app/models/hat.dart';
 

--- a/packages/brick_offline_first/lib/src/mixins/delete_all_mixin.dart
+++ b/packages/brick_offline_first/lib/src/mixins/delete_all_mixin.dart
@@ -1,5 +1,4 @@
 import 'package:brick_offline_first/offline_first.dart';
-import 'package:brick_offline_first/offline_first_with_rest.dart';
 
 /// Adds functions [deleteAll] and [deleteAllExcept]
 mixin DeleteAllMixin<T extends OfflineFirstModel> on OfflineFirstRepository<T> {

--- a/packages/brick_offline_first/lib/src/offline_first_with_rest/offline_first_with_rest_repository.dart
+++ b/packages/brick_offline_first/lib/src/offline_first_with_rest/offline_first_with_rest_repository.dart
@@ -1,4 +1,3 @@
-import 'package:brick_core/core.dart';
 import 'package:brick_offline_first/src/offline_queue/request_sqlite_cache_manager.dart';
 import 'package:brick_sqlite/memory_cache_provider.dart';
 import 'package:brick_offline_first/offline_first.dart';
@@ -8,7 +7,6 @@ import 'package:brick_rest/rest.dart' show RestProvider, RestException;
 import 'package:brick_offline_first_abstract/abstract.dart' show OfflineFirstWithRestModel;
 import 'package:brick_sqlite_abstract/db.dart' show Migration;
 
-import 'package:brick_sqlite/sqlite.dart';
 import 'package:brick_offline_first/src/offline_queue/offline_queue_http_client.dart';
 import 'package:brick_offline_first/src/offline_queue/offline_request_queue.dart';
 

--- a/packages/brick_offline_first/test/mixins/delete_all_mixin_test.dart
+++ b/packages/brick_offline_first/test/mixins/delete_all_mixin_test.dart
@@ -9,7 +9,6 @@ import 'package:brick_sqlite/memory_cache_provider.dart';
 import 'package:brick_offline_first/offline_first_with_rest.dart';
 import 'package:brick_sqlite/sqlite.dart';
 
-import 'package:brick_offline_first/offline_first.dart';
 import 'package:sqflite_common/sqlite_api.dart';
 
 import '../offline_first/helpers/__mocks__.dart';

--- a/packages/brick_offline_first/test/mixins/destructive_local_sync_from_remote_mixin_test.dart
+++ b/packages/brick_offline_first/test/mixins/destructive_local_sync_from_remote_mixin_test.dart
@@ -9,7 +9,6 @@ import 'package:brick_sqlite/memory_cache_provider.dart';
 import 'package:brick_offline_first/offline_first_with_rest.dart';
 import 'package:brick_sqlite/sqlite.dart';
 
-import 'package:brick_offline_first/offline_first.dart';
 import 'package:sqflite_common/sqlite_api.dart';
 
 import '../offline_first/helpers/__mocks__.dart';

--- a/packages/brick_offline_first/test/offline_first/helpers/__mocks__.dart
+++ b/packages/brick_offline_first/test/offline_first/helpers/__mocks__.dart
@@ -6,7 +6,6 @@ import 'package:brick_sqlite/memory_cache_provider.dart';
 import 'package:brick_sqlite/sqlite.dart';
 
 import 'package:brick_sqlite_abstract/db.dart';
-import 'package:brick_offline_first/offline_first.dart';
 import 'package:sqflite_common/sqlite_api.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 export 'package:brick_offline_first/offline_first.dart';

--- a/packages/brick_offline_first/test/offline_first/offline_first_adapter_test.dart
+++ b/packages/brick_offline_first/test/offline_first/offline_first_adapter_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:test/test.dart' show TypeMatcher;
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'helpers/__mocks__.dart';

--- a/packages/brick_offline_first/test/offline_first/offline_first_model_test.dart
+++ b/packages/brick_offline_first/test/offline_first/offline_first_model_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:test/test.dart' show TypeMatcher;
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 import 'helpers/__mocks__.dart';

--- a/packages/brick_offline_first_with_rest_build/CHANGELOG.md
+++ b/packages/brick_offline_first_with_rest_build/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Remove unnecessary import in `brick.g.dart`
+
 ## 1.1.4
 
 * Always use `whereType<T>` casts after awaiting `Future.wait()` in Rest deserializing adapters.

--- a/packages/brick_offline_first_with_rest_build/lib/src/offline_first_model_dictionary_generator.dart
+++ b/packages/brick_offline_first_with_rest_build/lib/src/offline_first_model_dictionary_generator.dart
@@ -8,8 +8,6 @@ import 'dart:convert';
 import 'package:brick_sqlite/sqlite.dart' show SqliteModel, SqliteAdapter, SqliteModelDictionary, RuntimeSqliteColumnDefinition;
 import 'package:brick_rest/rest.dart' show RestProvider, RestModel, RestAdapter, RestModelDictionary;
 // ignore: unused_import, unused_shown_name
-import 'package:brick_core/core.dart' show Query, QueryAction;
-// ignore: unused_import, unused_shown_name
 import 'package:sqflite/sqflite.dart' show DatabaseExecutor;""";
 
   /// All classes annotated with `@ConnectOfflineFirstWithRest`

--- a/packages/brick_offline_first_with_rest_build/pubspec.yaml
+++ b/packages/brick_offline_first_with_rest_build/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   brick_rest: ^1.0.0+3
   brick_rest_generators: ^1.0.2
   brick_sqlite_abstract: ^1.0.0+1
-  brick_sqlite_generators: ^1.1.3
+  brick_sqlite_generators: ^1.1.4
   build: ^2.0.0
   dart_style: ^2.0.0
   logging: ^1.0.0

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_primitive_fields.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_generator/test_primitive_fields.dart
@@ -114,6 +114,7 @@ Future<PrimitiveFields> _$PrimitiveFieldsFromSqlite(Map<String, dynamic> data,
           ? null
           : jsonDecode(data['nullable_list_casing'])
               .map((d) => d as int > -1 ? Casing.values[d] : null)
+              ?.whereType<Casing>()
               .toList()
               .cast<Casing>(),
       nullableDateTime: data['nullable_date_time'] == null
@@ -132,6 +133,7 @@ Future<PrimitiveFields> _$PrimitiveFieldsFromSqlite(Map<String, dynamic> data,
       casing: Casing.values[data['casing'] as int],
       listCasing: jsonDecode(data['list_casing'])
           .map((d) => d as int > -1 ? Casing.values[d] : null)
+          .whereType<Casing>()
           .toList()
           .cast<Casing>(),
       dateTime: DateTime.parse(data['date_time'] as String))

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_model_dictionary_generator_test.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_model_dictionary_generator_test.dart
@@ -15,8 +15,6 @@ import 'dart:convert';
 import 'package:brick_sqlite/sqlite.dart' show SqliteModel, SqliteAdapter, SqliteModelDictionary, RuntimeSqliteColumnDefinition;
 import 'package:brick_rest/rest.dart' show RestProvider, RestModel, RestAdapter, RestModelDictionary;
 // ignore: unused_import, unused_shown_name
-import 'package:brick_core/core.dart' show Query, QueryAction;
-// ignore: unused_import, unused_shown_name
 import 'package:sqflite/sqflite.dart' show DatabaseExecutor;
 
 import 'models/person.dart';

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_association.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_association.dart
@@ -11,8 +11,6 @@ final output = r'''
 // GENERATED CODE DO NOT EDIT
 // This file should be version controlled
 import 'package:brick_sqlite_abstract/db.dart';
-// ignore: unused_import
-import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{};

--- a/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_associations.dart
+++ b/packages/brick_offline_first_with_rest_build/test/offline_first_schema_generator/test_with_associations.dart
@@ -11,8 +11,6 @@ final output = r'''
 // GENERATED CODE DO NOT EDIT
 // This file should be version controlled
 import 'package:brick_sqlite_abstract/db.dart';
-// ignore: unused_import
-import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{};

--- a/packages/brick_sqlite/lib/src/sqlite_adapter.dart
+++ b/packages/brick_sqlite/lib/src/sqlite_adapter.dart
@@ -2,7 +2,6 @@ import 'package:sqflite/sqflite.dart';
 
 import 'package:brick_core/core.dart';
 import 'package:brick_sqlite_abstract/db.dart';
-import 'package:brick_sqlite_abstract/sqlite_model.dart';
 import 'package:brick_sqlite/src/sqlite_provider.dart';
 import 'package:brick_sqlite/src/runtime_sqlite_column_definition.dart';
 

--- a/packages/brick_sqlite/test/sqlite_test.dart
+++ b/packages/brick_sqlite/test/sqlite_test.dart
@@ -1,5 +1,4 @@
 import 'package:brick_core/core.dart';
-import 'package:brick_sqlite_abstract/sqlite_model.dart';
 import 'package:brick_sqlite_abstract/db.dart';
 import 'package:brick_sqlite/sqlite.dart';
 import 'package:test/test.dart';

--- a/packages/brick_sqlite_abstract/lib/src/db/schema/schema_difference.dart
+++ b/packages/brick_sqlite_abstract/lib/src/db/schema/schema_difference.dart
@@ -1,9 +1,5 @@
-import 'package:brick_sqlite_abstract/src/db/schema/schema_index.dart';
-
 import '../migration_commands.dart';
 import '../schema.dart';
-import 'schema_column.dart';
-import 'schema_table.dart';
 import 'package:collection/collection.dart';
 
 /// Compares two schemas to produce migrations that conver the difference

--- a/packages/brick_sqlite_abstract/test/db/migration_commands_test.dart
+++ b/packages/brick_sqlite_abstract/test/db/migration_commands_test.dart
@@ -1,5 +1,3 @@
-import 'package:test/test.dart';
-import 'package:brick_sqlite_abstract/db.dart';
 import '__mocks__.dart';
 
 void main() {

--- a/packages/brick_sqlite_generators/CHANGELOG.md
+++ b/packages/brick_sqlite_generators/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Fix casting when deserializing enums. The analyzer does not alert for `cast` on a list that could contain nullable values; if the field type is non-nullable, null types must be removed before the cast.
+* Remove unnecessary import in `schema.g.dart`
 
 ## 1.1.3
 

--- a/packages/brick_sqlite_generators/CHANGELOG.md
+++ b/packages/brick_sqlite_generators/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 1.1.4
+
 * Fix casting when deserializing enums. The analyzer does not alert for `cast` on a list that could contain nullable values; if the field type is non-nullable, null types must be removed before the cast.
 * Remove unnecessary import in `schema.g.dart`
 

--- a/packages/brick_sqlite_generators/lib/src/sqlite_fields.dart
+++ b/packages/brick_sqlite_generators/lib/src/sqlite_fields.dart
@@ -7,7 +7,6 @@ import 'package:brick_sqlite_abstract/annotations.dart';
 import 'package:brick_build/src/annotation_finder.dart';
 import 'package:brick_build/src/utils/fields_for_class.dart';
 import 'package:brick_build/src/utils/string_helpers.dart';
-import 'package:brick_sqlite_abstract/db.dart' show Column;
 
 /// Find `@Sqlite` given a field
 class SqliteAnnotationFinder extends AnnotationFinder<Sqlite> {

--- a/packages/brick_sqlite_generators/lib/src/sqlite_schema/sqlite_schema_generator.dart
+++ b/packages/brick_sqlite_generators/lib/src/sqlite_schema/sqlite_schema_generator.dart
@@ -34,8 +34,6 @@ class SqliteSchemaGenerator {
       // GENERATED CODE DO NOT EDIT
       // This file should be version controlled
       import 'package:brick_sqlite_abstract/db.dart';
-      // ignore: unused_import
-      import 'package:brick_sqlite_abstract/db.dart' show Migratable;
       ${parts.join("\n")}
 
       /// All intelligently-generated migrations from all `@Migratable` classes on disk

--- a/packages/brick_sqlite_generators/lib/src/sqlite_serdes_generator.dart
+++ b/packages/brick_sqlite_generators/lib/src/sqlite_serdes_generator.dart
@@ -1,7 +1,5 @@
 import 'package:analyzer/dart/element/element.dart';
 import 'package:brick_build/generators.dart';
-// ignore: implementation_imports
-import 'package:brick_build/src/serdes_generator.dart';
 import 'package:brick_sqlite_abstract/annotations.dart';
 import 'package:brick_sqlite_abstract/db.dart' show InsertForeignKey;
 import 'package:brick_sqlite_abstract/sqlite_model.dart';

--- a/packages/brick_sqlite_generators/pubspec.yaml
+++ b/packages/brick_sqlite_generators/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_sqlite_ge
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 1.1.3
+version: 1.1.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_all_field_types.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_all_field_types.dart
@@ -6,8 +6,6 @@ final output = r'''
 // GENERATED CODE DO NOT EDIT
 // This file should be version controlled
 import 'package:brick_sqlite_abstract/db.dart';
-// ignore: unused_import
-import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{};

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_index_annotation.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_index_annotation.dart
@@ -5,8 +5,6 @@ final output = r'''
 // GENERATED CODE DO NOT EDIT
 // This file should be version controlled
 import 'package:brick_sqlite_abstract/db.dart';
-// ignore: unused_import
-import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{};

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_nullable.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_nullable.dart
@@ -4,8 +4,6 @@ final output = r'''
 // GENERATED CODE DO NOT EDIT
 // This file should be version controlled
 import 'package:brick_sqlite_abstract/db.dart';
-// ignore: unused_import
-import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{};

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_many_association.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_many_association.dart
@@ -15,8 +15,6 @@ final output = r'''
 // GENERATED CODE DO NOT EDIT
 // This file should be version controlled
 import 'package:brick_sqlite_abstract/db.dart';
-// ignore: unused_import
-import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{};

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_one_association.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_one_to_one_association.dart
@@ -15,8 +15,6 @@ final output = r'''
 // GENERATED CODE DO NOT EDIT
 // This file should be version controlled
 import 'package:brick_sqlite_abstract/db.dart';
-// ignore: unused_import
-import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{};

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_simple.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_simple.dart
@@ -46,8 +46,6 @@ final output = r'''
 // GENERATED CODE DO NOT EDIT
 // This file should be version controlled
 import 'package:brick_sqlite_abstract/db.dart';
-// ignore: unused_import
-import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{};

--- a/packages/brick_sqlite_generators/test/sqlite_schema/test_sqlite_column_type.dart
+++ b/packages/brick_sqlite_generators/test/sqlite_schema/test_sqlite_column_type.dart
@@ -6,8 +6,6 @@ final output = r'''
 // GENERATED CODE DO NOT EDIT
 // This file should be version controlled
 import 'package:brick_sqlite_abstract/db.dart';
-// ignore: unused_import
-import 'package:brick_sqlite_abstract/db.dart' show Migratable;
 
 /// All intelligently-generated migrations from all `@Migratable` classes on disk
 final migrations = <Migration>{};


### PR DESCRIPTION
* Removes imports in packages
* Removes imports from `brick_offline_first_with_rest_build` output
* * Removes imports from `brick_sqlite_generators` output