### PR TITLE
permit part file inclusion

### DIFF
--- a/packages/brick_build/lib/src/builders/adapter_builder.dart
+++ b/packages/brick_build/lib/src/builders/adapter_builder.dart
@@ -42,6 +42,6 @@ class AdapterBuilder<_ClassAnnotation> extends BaseBuilder<_ClassAnnotation> {
 
   @override
   Map<String, List<String>> get buildExtensions => {
-        '.model.dart': [outputExtension]
+        '.dart': [outputExtension]
       };
 }

--- a/packages/brick_build/lib/src/builders/adapter_builder.dart
+++ b/packages/brick_build/lib/src/builders/adapter_builder.dart
@@ -42,6 +42,6 @@ class AdapterBuilder<_ClassAnnotation> extends BaseBuilder<_ClassAnnotation> {
 
   @override
   Map<String, List<String>> get buildExtensions => {
-        '.dart': [outputExtension]
+        '.model.dart': [outputExtension]
       };
 }

--- a/packages/brick_offline_first_with_graphql_build/CHANGELOG.md
+++ b/packages/brick_offline_first_with_graphql_build/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+## 1.2.0
+
+* Permit using `part` and `part of` files outside of models
+
 ## 1.1.1
 
 * Loosen dependency restrictions to major versions

--- a/packages/brick_offline_first_with_graphql_build/build.yaml
+++ b/packages/brick_offline_first_with_graphql_build/build.yaml
@@ -37,6 +37,11 @@ builders:
     applies_builders: ["source_gen|combining_builder"]
     defaults:
       generate_for:
+        include:
+          - lib/**/*.model.dart
+          - lib/brick/db/*.migration.dart
+          - lib/brick/db/schema.g.dart
+          - lib/brick/brick.g.dart
         exclude:
           - lib/brick/adapters/*.dart
           - brick/adapters/*.dart

--- a/packages/brick_offline_first_with_graphql_build/build.yaml
+++ b/packages/brick_offline_first_with_graphql_build/build.yaml
@@ -18,6 +18,11 @@ builders:
     auto_apply: root_package
     defaults:
       generate_for:
+        include:
+          - lib/**/*.model.dart
+          - lib/brick/db/*.migration.dart
+          - lib/brick/db/schema.g.dart
+          - lib/brick/brick.g.dart
         exclude:
           - lib/brick/adapters/*.dart
           - brick/adapters/*.dart

--- a/packages/brick_offline_first_with_graphql_build/pubspec.yaml
+++ b/packages/brick_offline_first_with_graphql_build/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_offline_f
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 1.1.1
+version: 1.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/brick_offline_first_with_rest_build/CHANGELOG.md
+++ b/packages/brick_offline_first_with_rest_build/CHANGELOG.md
@@ -1,5 +1,6 @@
-## Unreleased
+## 2.1.0
 
+* Permit using `part` and `part of` files outside of models
 * Loosen dependency restrictions to major versions
 
 ## 2.0.0

--- a/packages/brick_offline_first_with_rest_build/build.yaml
+++ b/packages/brick_offline_first_with_rest_build/build.yaml
@@ -18,6 +18,11 @@ builders:
     auto_apply: root_package
     defaults:
       generate_for:
+        include:
+          - lib/**/*.model.dart
+          - lib/brick/db/*.migration.dart
+          - lib/brick/db/schema.g.dart
+          - lib/brick/brick.g.dart
         exclude:
           - lib/brick/adapters/*.dart
           - brick/adapters/*.dart
@@ -32,6 +37,11 @@ builders:
     applies_builders: ["source_gen|combining_builder"]
     defaults:
       generate_for:
+        include:
+          - lib/**/*.model.dart
+          - lib/brick/db/*.migration.dart
+          - lib/brick/db/schema.g.dart
+          - lib/brick/brick.g.dart
         exclude:
           - lib/brick/adapters/*.dart
           - brick/adapters/*.dart

--- a/packages/brick_offline_first_with_rest_build/pubspec.yaml
+++ b/packages/brick_offline_first_with_rest_build/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_offline_f
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 2.0.0
+version: 2.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/brick_offline_first_with_rest_build/pubspec.yaml
+++ b/packages/brick_offline_first_with_rest_build/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_offline_f
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 2.1.0
+version: 2.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
Restrict build discover to model, migration, and brick.g.dart files. 