### PR TITLE
Fix Docs for build_runner command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Brick is an extensible query interface for Dart applications. It's an [all-in-on
     mkdir -p lib/brick/adapters lib/brick/db;
     ```
 1. Add [models](https://engineering.dutchie.com/brick/#/data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
-1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner run` if you're not using Flutter) and [sometimes migrations](https://engineering.dutchie.com/brick/#/sqlite?id=intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
+1. Run `flutter pub run build_runner build` to generate your models (or `pub run build_runner build` if you're not using Flutter) and [sometimes migrations](https://engineering.dutchie.com/brick/#/sqlite?id=intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
 1. Extend [an existing repository](https://engineering.dutchie.com/brick/#/data/repositories) or create your own:
     ```dart
     // lib/brick/repository.dart

--- a/docs/home.md
+++ b/docs/home.md
@@ -16,7 +16,7 @@
     mkdir -p lib/brick/adapters lib/brick/db;
     ```
 1. Add [models](https://greenbits.github.io/brick/#/data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
-1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner run` if you're not using Flutter) and [sometimes migrations](sqlite.md). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
+1. Run `flutter pub run build_runner build` to generate your models (or `pub run build_runner build` if you're not using Flutter) and [sometimes migrations](sqlite.md). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
 1. Extend [an existing repository](data/repositories.md) or create your own:
     ```dart
     // lib/brick/repository.dart

--- a/docs/introduction/setup.md
+++ b/docs/introduction/setup.md
@@ -16,7 +16,7 @@
     mkdir -p lib/brick/adapters lib/brick/db;
     ```
 1. Add [models](https://greenbits.github.io/brick/#/data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
-1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner run` if you're not using Flutter) and [sometimes migrations](sqlite.md). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
+1. Run `flutter pub run build_runner build` to generate your models (or `pub run build_runner build` if you're not using Flutter) and [sometimes migrations](sqlite.md). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
 1. Extend [an existing repository](data/repositories.md) or create your own:
     ```dart
     // lib/brick/repository.dart


### PR DESCRIPTION
Fixing a mistake in the docs that is a showstopper for anyone who hasn't used build_runner before (me!). `run build_runner run` results in the following:

```
flutter pub run build_runner run  
[INFO] Generating build script...
[INFO] Generating build script completed, took 439ms

[SEVERE] Must specify an executable to run.
[SEVERE] Performs a single build, and executes a Dart script with the given arguments.

Usage: build_runner run [build-arguments] <executable> [-- [script-arguments]]
-h, --help                          Print this usage information.
-d, --delete-conflicting-outputs    By default, the user will be prompted to
                                    delete any files which already exist but
                                    were not known to be generated by this
                                    specific build script.
                                    
                                    Enabling this option skips the prompt and
                                    deletes the files. This should typically be
                                    used in continues integration servers and
                                    tests, but not otherwise.
    --low-resources-mode            Reduce the amount of memory consumed by the
                                    build process. This will slow down builds
                                    but allow them to progress in resource
                                    constrained environments.
-c, --config                        Read `build.<name>.yaml` instead of the
                                    default `build.yaml`
    --[no-]track-performance        Enables performance tracking and the /$perf
                                    page.
    --log-performance               A directory to write performance logs to,
                                    must be in the current package. Implies
                                    `--track-performance`.
-o, --output                        A directory to copy the fully built package
                                    to. Or a mapping from a top-level directory
                                    in the package to the directory to write a
                                    filtered build output to. For example
                                    "web:deploy".
-v, --verbose                       Enables verbose logging.
-r, --[no-]release                  Build with release mode defaults for
                                    builders.
    --define                        Sets the global `options` config for a
                                    builder by key.
    --[no-]symlink                  Symlink files in the output directories,
                                    instead of copying.
    --build-filter                  An explicit filter of files to build.
                                    Relative paths and `package:` uris are
                                    supported, including glob syntax for paths
                                    portions (but not package names).
                                    
                                    If multiple filters are applied then outputs
                                    matching any filter will be built (they do
                                    not need to match all filters).
    --enable-experiment             A list of dart language experiments to
                                    enable.

Run "build_runner help" to see global options.
pub finished with exit code 64
```