### PR TITLE
Clean up links in intro ducumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Brick is an extensible query interface for Dart applications. It's an [all-in-on
     mkdir -p lib/brick/adapters lib/brick/db;
     ```
 1. Add [models](docs/data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
-1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner build` if you're not using Flutter) and [sometimes migrations](docs/sqlite.md#intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
+1. Run `flutter pub run build_runner build` to generate your models (or `pub run build_runner build` if you're not using Flutter) and [sometimes migrations](docs/sqlite.md#intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
 1. Extend [an existing repository](docs/data/repositories) or create your own:
     ```dart
     // lib/brick/repository.dart

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ An intuitive way to work with persistent data in Dart.
 
 * Out-of-the-box [offline access](packages/brick_offline_first) to data
 * [Handle and hide](packages/brick_build) complex serialization/deserialization logic
-* Single [access point](https://engineering.dutchie.com/brick/#/data/repositories) and opinionated DSL
-* Automatic, [intelligently-generated migrations](packages/brick_sqlite)
-* Legible [querying interface](https://engineering.dutchie.com/brick/#/data/query)
+* Single [access point](docs/data/repositories) and opinionated DSL
+* Automatic, [intelligently-generated migrations](docs/sqlite.md#intelligent-migrations)
+* Legible [querying interface](docs/data/query)
 
 ## What is Brick?
 
@@ -32,9 +32,9 @@ Brick is an extensible query interface for Dart applications. It's an [all-in-on
     ```bash
     mkdir -p lib/brick/adapters lib/brick/db;
     ```
-1. Add [models](https://engineering.dutchie.com/brick/#/data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
-1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner run` if you're not using Flutter) and [sometimes migrations](https://engineering.dutchie.com/brick/#/sqlite?id=intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
-1. Extend [an existing repository](https://engineering.dutchie.com/brick/#/data/repositories) or create your own:
+1. Add [models](docs/data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
+1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner run` if you're not using Flutter) and [sometimes migrations](docs/sqlite.md#intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
+1. Extend [an existing repository](docs/data/repositories) or create your own:
     ```dart
     // lib/brick/repository.dart
     import 'package:brick_offline_first/offline_first_with_rest.dart';

--- a/docs/home.md
+++ b/docs/home.md
@@ -16,7 +16,7 @@
     mkdir -p lib/brick/adapters lib/brick/db;
     ```
 1. Add [models](https://greenbits.github.io/brick/#/data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
-1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner run` if you're not using Flutter) and [sometimes migrations](sqlite.md#intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
+1. Run `flutter pub run build_runner build` to generate your models (or `pub run build_runner build` if you're not using Flutter) and [sometimes migrations](sqlite.md#intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
 1. Extend [an existing repository](data/repositories.md) or create your own:
     ```dart
     // lib/brick/repository.dart

--- a/docs/home.md
+++ b/docs/home.md
@@ -16,7 +16,7 @@
     mkdir -p lib/brick/adapters lib/brick/db;
     ```
 1. Add [models](https://greenbits.github.io/brick/#/data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
-1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner run` if you're not using Flutter) and [sometimes migrations](sqlite.md). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
+1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner run` if you're not using Flutter) and [sometimes migrations](sqlite.md#intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
 1. Extend [an existing repository](data/repositories.md) or create your own:
     ```dart
     // lib/brick/repository.dart

--- a/docs/introduction/setup.md
+++ b/docs/introduction/setup.md
@@ -16,7 +16,7 @@
     mkdir -p lib/brick/adapters lib/brick/db;
     ```
 1. Add [models](../data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
-1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner build` if you're not using Flutter) and [sometimes migrations](../sqlite.md#intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
+1. Run `flutter pub run build_runner build` to generate your models (or `pub run build_runner build` if you're not using Flutter) and [sometimes migrations](../sqlite.md#intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
 1. Extend [an existing repository](../data/repositories.md) or create your own:
     ```dart
     // lib/brick/repository.dart

--- a/docs/introduction/setup.md
+++ b/docs/introduction/setup.md
@@ -15,9 +15,9 @@
     ```bash
     mkdir -p lib/brick/adapters lib/brick/db;
     ```
-1. Add [models](https://greenbits.github.io/brick/#/data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
-1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner run` if you're not using Flutter) and [sometimes migrations](sqlite.md). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
-1. Extend [an existing repository](data/repositories.md) or create your own:
+1. Add [models](../data/models) that contain your app logic. Models **must be** saved with the `.model.dart` suffix (i.e. `lib/brick/models/person.model.dart`).
+1. Run `flutter pub run build_runner run` to generate your models (or `pub run build_runner run` if you're not using Flutter) and [sometimes migrations](../sqlite.md#intelligent-migrations). Rerun after every new model change or `flutter pub run build_runner watch` for automatic generations.
+1. Extend [an existing repository](../data/repositories.md) or create your own:
     ```dart
     // lib/brick/repository.dart
     import 'package:brick_offline_first/offline_first_with_rest.dart';

--- a/example_graphql/.metadata
+++ b/example_graphql/.metadata
@@ -1,10 +1,30 @@
 # This file tracks properties of this Flutter project.
 # Used by Flutter tool to assess capabilities and perform upgrades etc.
 #
-# This file should be version controlled and should not be manually edited.
+# This file should be version controlled.
 
 version:
-  revision: 27321ebbad34b0a3fafe99fac037102196d655ff
+  revision: 135454af32477f815a7525073027a3ff9eff1bfd
   channel: stable
 
 project_type: app
+
+# Tracks metadata for the flutter migrate command
+migration:
+  platforms:
+    - platform: root
+      create_revision: 135454af32477f815a7525073027a3ff9eff1bfd
+      base_revision: 135454af32477f815a7525073027a3ff9eff1bfd
+    - platform: macos
+      create_revision: 135454af32477f815a7525073027a3ff9eff1bfd
+      base_revision: 135454af32477f815a7525073027a3ff9eff1bfd
+
+  # User provided section
+
+  # List of Local paths (relative to this file) that should be
+  # ignored by the migrate tool.
+  #
+  # Files that are not part of the templates will be ignored by default.
+  unmanaged_files:
+    - 'lib/main.dart'
+    - 'ios/Runner.xcodeproj/project.pbxproj'


### PR DESCRIPTION
Clean up a few links in the documentation I was reading.  Kind of tricky issue because the relative links won't work if clicked from pub.dev, but the previous `engineering.dutchie.com` doesn't seem to be in service any longer either. Could put full url to readme files within github repo potentially.  