### PR TITLE
eng(supabase): add query supabase transformer tests

### DIFF
--- a/packages/brick_supabase/test/__mocks__.dart
+++ b/packages/brick_supabase/test/__mocks__.dart
@@ -33,12 +33,10 @@ Future<Map<String, dynamic>> _$DemoModelToSupabase(DemoModel instance) async {
 
 class DemoModelAdapter extends SupabaseAdapter<DemoModel> {
   @override
-  DemoModel fromSupabase(data, {required provider, repository}) =>
-      _$DemoModelFromSupabase(data);
+  DemoModel fromSupabase(data, {required provider, repository}) => _$DemoModelFromSupabase(data);
 
   @override
-  Future<Map<String, dynamic>> toSupabase(instance,
-          {required provider, repository}) async =>
+  Future<Map<String, dynamic>> toSupabase(instance, {required provider, repository}) async =>
       await _$DemoModelToSupabase(instance);
 
   @override
@@ -89,13 +87,11 @@ class DemoNestedAssociationModel extends SupabaseModel {
   });
 }
 
-DemoNestedAssociationModel _$DemoNestedAssociationModelFromSupabase(
-    Map<String, dynamic> json) {
+DemoNestedAssociationModel _$DemoNestedAssociationModelFromSupabase(Map<String, dynamic> json) {
   return DemoNestedAssociationModel(
     id: json['id'] as String,
     name: json['name'] as String,
-    nested: _$DemoAssociationModelFromSupabase(
-        json['nested'] as Map<String, dynamic>),
+    nested: _$DemoAssociationModelFromSupabase(json['nested'] as Map<String, dynamic>),
   );
 }
 
@@ -108,16 +104,13 @@ Future<Map<String, dynamic>> _$DemoNestedAssociationModelToSupabase(
   };
 }
 
-class DemoNestedAssociationModelAdapter
-    extends SupabaseAdapter<DemoNestedAssociationModel> {
+class DemoNestedAssociationModelAdapter extends SupabaseAdapter<DemoNestedAssociationModel> {
   @override
-  DemoNestedAssociationModel fromSupabase(data,
-          {required provider, repository}) =>
+  DemoNestedAssociationModel fromSupabase(data, {required provider, repository}) =>
       _$DemoNestedAssociationModelFromSupabase(data);
 
   @override
-  Future<Map<String, dynamic>> toSupabase(instance,
-          {required provider, repository}) async =>
+  Future<Map<String, dynamic>> toSupabase(instance, {required provider, repository}) async =>
       await _$DemoNestedAssociationModelToSupabase(instance);
 
   @override
@@ -170,8 +163,7 @@ class DemoAssociationModel extends SupabaseModel {
   });
 }
 
-DemoAssociationModel _$DemoAssociationModelFromSupabase(
-    Map<String, dynamic> json) {
+DemoAssociationModel _$DemoAssociationModelFromSupabase(Map<String, dynamic> json) {
   return DemoAssociationModel(
     id: json['id'] as String,
     name: json['name'] as String,
@@ -179,23 +171,20 @@ DemoAssociationModel _$DemoAssociationModelFromSupabase(
   );
 }
 
-Future<Map<String, dynamic>> _$DemoAssociationModelToSupabase(
-    DemoAssociationModel instance) async {
+Future<Map<String, dynamic>> _$DemoAssociationModelToSupabase(DemoAssociationModel instance) async {
   return <String, dynamic>{
     'id': instance.id,
     'name': instance.name,
   };
 }
 
-class DemoAssociationModelAdapter
-    extends SupabaseAdapter<DemoAssociationModel> {
+class DemoAssociationModelAdapter extends SupabaseAdapter<DemoAssociationModel> {
   @override
   DemoAssociationModel fromSupabase(data, {required provider, repository}) =>
       _$DemoAssociationModelFromSupabase(data);
 
   @override
-  Future<Map<String, dynamic>> toSupabase(instance,
-          {required provider, repository}) async =>
+  Future<Map<String, dynamic>> toSupabase(instance, {required provider, repository}) async =>
       await _$DemoAssociationModelToSupabase(instance);
 
   @override

--- a/packages/brick_supabase/test/__mocks__.dart
+++ b/packages/brick_supabase/test/__mocks__.dart
@@ -6,9 +6,12 @@ class DemoModel extends SupabaseModel {
 
   final String name;
 
+  final int age;
+
   DemoModel({
     required this.id,
     required this.name,
+    required this.age,
   });
 }
 
@@ -16,6 +19,7 @@ DemoModel _$DemoModelFromSupabase(Map<String, dynamic> json) {
   return DemoModel(
     id: json['id'] as String,
     name: json['name'] as String,
+    age: json['age'] as int,
   );
 }
 
@@ -23,15 +27,18 @@ Future<Map<String, dynamic>> _$DemoModelToSupabase(DemoModel instance) async {
   return <String, dynamic>{
     'id': instance.id,
     'name': instance.name,
+    'age': instance.age,
   };
 }
 
 class DemoModelAdapter extends SupabaseAdapter<DemoModel> {
   @override
-  DemoModel fromSupabase(data, {required provider, repository}) => _$DemoModelFromSupabase(data);
+  DemoModel fromSupabase(data, {required provider, repository}) =>
+      _$DemoModelFromSupabase(data);
 
   @override
-  Future<Map<String, dynamic>> toSupabase(instance, {required provider, repository}) async =>
+  Future<Map<String, dynamic>> toSupabase(instance,
+          {required provider, repository}) async =>
       await _$DemoModelToSupabase(instance);
 
   @override
@@ -46,6 +53,10 @@ class DemoModelAdapter extends SupabaseAdapter<DemoModel> {
     'name': const RuntimeSupabaseColumnDefinition(
       association: false,
       columnName: 'name',
+    ),
+    'age': const RuntimeSupabaseColumnDefinition(
+      association: false,
+      columnName: 'age',
     ),
   };
 
@@ -78,11 +89,13 @@ class DemoNestedAssociationModel extends SupabaseModel {
   });
 }
 
-DemoNestedAssociationModel _$DemoNestedAssociationModelFromSupabase(Map<String, dynamic> json) {
+DemoNestedAssociationModel _$DemoNestedAssociationModelFromSupabase(
+    Map<String, dynamic> json) {
   return DemoNestedAssociationModel(
     id: json['id'] as String,
     name: json['name'] as String,
-    nested: _$DemoAssociationModelFromSupabase(json['nested'] as Map<String, dynamic>),
+    nested: _$DemoAssociationModelFromSupabase(
+        json['nested'] as Map<String, dynamic>),
   );
 }
 
@@ -95,13 +108,16 @@ Future<Map<String, dynamic>> _$DemoNestedAssociationModelToSupabase(
   };
 }
 
-class DemoNestedAssociationModelAdapter extends SupabaseAdapter<DemoNestedAssociationModel> {
+class DemoNestedAssociationModelAdapter
+    extends SupabaseAdapter<DemoNestedAssociationModel> {
   @override
-  DemoNestedAssociationModel fromSupabase(data, {required provider, repository}) =>
+  DemoNestedAssociationModel fromSupabase(data,
+          {required provider, repository}) =>
       _$DemoNestedAssociationModelFromSupabase(data);
 
   @override
-  Future<Map<String, dynamic>> toSupabase(instance, {required provider, repository}) async =>
+  Future<Map<String, dynamic>> toSupabase(instance,
+          {required provider, repository}) async =>
       await _$DemoNestedAssociationModelToSupabase(instance);
 
   @override
@@ -154,7 +170,8 @@ class DemoAssociationModel extends SupabaseModel {
   });
 }
 
-DemoAssociationModel _$DemoAssociationModelFromSupabase(Map<String, dynamic> json) {
+DemoAssociationModel _$DemoAssociationModelFromSupabase(
+    Map<String, dynamic> json) {
   return DemoAssociationModel(
     id: json['id'] as String,
     name: json['name'] as String,
@@ -162,20 +179,23 @@ DemoAssociationModel _$DemoAssociationModelFromSupabase(Map<String, dynamic> jso
   );
 }
 
-Future<Map<String, dynamic>> _$DemoAssociationModelToSupabase(DemoAssociationModel instance) async {
+Future<Map<String, dynamic>> _$DemoAssociationModelToSupabase(
+    DemoAssociationModel instance) async {
   return <String, dynamic>{
     'id': instance.id,
     'name': instance.name,
   };
 }
 
-class DemoAssociationModelAdapter extends SupabaseAdapter<DemoAssociationModel> {
+class DemoAssociationModelAdapter
+    extends SupabaseAdapter<DemoAssociationModel> {
   @override
   DemoAssociationModel fromSupabase(data, {required provider, repository}) =>
       _$DemoAssociationModelFromSupabase(data);
 
   @override
-  Future<Map<String, dynamic>> toSupabase(instance, {required provider, repository}) async =>
+  Future<Map<String, dynamic>> toSupabase(instance,
+          {required provider, repository}) async =>
       await _$DemoAssociationModelToSupabase(instance);
 
   @override

--- a/packages/brick_supabase/test/query_supabase_transformer_test.dart
+++ b/packages/brick_supabase/test/query_supabase_transformer_test.dart
@@ -141,10 +141,9 @@ void main() {
       test('orderBy', () {
         final query = Query(providerArgs: {'orderBy': 'name asc'});
         final queryTransformer = _buildTransformer<DemoModel>(query);
-        final filterBuilder = queryTransformer
-            .select(_supabaseClient.from(DemoModelAdapter().tableName));
-        final transformBuilder =
-            queryTransformer.applyProviderArgs(filterBuilder);
+        final filterBuilder =
+            queryTransformer.select(_supabaseClient.from(DemoModelAdapter().tableName));
+        final transformBuilder = queryTransformer.applyProviderArgs(filterBuilder);
 
         expect(
           transformBuilder.query,
@@ -155,10 +154,9 @@ void main() {
       test('orderBy with descending order', () {
         final query = Query(providerArgs: {'orderBy': 'name desc'});
         final queryTransformer = _buildTransformer<DemoModel>(query);
-        final filterBuilder = queryTransformer
-            .select(_supabaseClient.from(DemoModelAdapter().tableName));
-        final transformBuilder =
-            queryTransformer.applyProviderArgs(filterBuilder);
+        final filterBuilder =
+            queryTransformer.select(_supabaseClient.from(DemoModelAdapter().tableName));
+        final transformBuilder = queryTransformer.applyProviderArgs(filterBuilder);
 
         expect(
           transformBuilder.query,
@@ -169,10 +167,9 @@ void main() {
       test('limit', () {
         final query = Query(providerArgs: {'limit': 10});
         final queryTransformer = _buildTransformer<DemoModel>(query);
-        final filterBuilder = queryTransformer
-            .select(_supabaseClient.from(DemoModelAdapter().tableName));
-        final transformBuilder =
-            queryTransformer.applyProviderArgs(filterBuilder);
+        final filterBuilder =
+            queryTransformer.select(_supabaseClient.from(DemoModelAdapter().tableName));
+        final transformBuilder = queryTransformer.applyProviderArgs(filterBuilder);
 
         expect(transformBuilder.query, 'select=id,name,age&limit=10');
       });
@@ -180,13 +177,11 @@ void main() {
       test('limit with referenced table', skip: true, () {});
 
       test('combined orderBy and limit', () {
-        final query =
-            Query(providerArgs: {'orderBy': 'name desc', 'limit': 20});
+        final query = Query(providerArgs: {'orderBy': 'name desc', 'limit': 20});
         final queryTransformer = _buildTransformer<DemoModel>(query);
-        final filterBuilder = queryTransformer
-            .select(_supabaseClient.from(DemoModelAdapter().tableName));
-        final transformBuilder =
-            queryTransformer.applyProviderArgs(filterBuilder);
+        final filterBuilder =
+            queryTransformer.select(_supabaseClient.from(DemoModelAdapter().tableName));
+        final transformBuilder = queryTransformer.applyProviderArgs(filterBuilder);
 
         expect(
           transformBuilder.query,

--- a/packages/brick_supabase/test/query_supabase_transformer_test.dart
+++ b/packages/brick_supabase/test/query_supabase_transformer_test.dart
@@ -1,15 +1,43 @@
 import 'package:brick_core/core.dart';
+import 'package:brick_supabase/brick_supabase.dart';
 import 'package:brick_supabase/src/query_supabase_transformer.dart';
 import 'package:brick_supabase/src/supabase_model.dart';
+import 'package:supabase/supabase.dart';
 import 'package:test/test.dart';
 
 import '__mocks__.dart';
 
-QuerySupabaseTransformer<T> _buildTransformer<T extends SupabaseModel>([Query? query]) {
+QuerySupabaseTransformer<T> _buildTransformer<T extends SupabaseModel>([
+  Query? query,
+]) {
   return QuerySupabaseTransformer<T>(
     modelDictionary: supabaseModelDictionary,
     query: query,
   );
+}
+
+final _supabaseClient = SupabaseClient(
+  'http://localhost:3000',
+  'supabaseKey',
+);
+
+extension _PostgrestBuilderExtension on PostgrestBuilder {
+  /// Get the URI from the builder.
+  Uri get uri {
+    var uriString = overrideSearchParams('', '').toString();
+
+    // Remove any trailing '&' or '?' (which is added by the overrideSearchParams)
+    if (uriString.endsWith('&') || uriString.endsWith('?')) {
+      uriString = uriString.substring(0, uriString.length - 1);
+    }
+
+    return Uri.parse(uriString);
+  }
+
+  /// Get the decoded query from the URI of the builder.
+  String get query {
+    return Uri.decodeQueryComponent(uri.query);
+  }
 }
 
 void main() {
@@ -17,60 +45,181 @@ void main() {
     group('#selectFields', () {
       test('no association', () {
         final transformer = _buildTransformer<DemoModel>();
-        expect(transformer.selectFields, 'id,name');
+        expect(transformer.selectFields, 'id,name,age');
       });
 
       test('association', () {
         final transformer = _buildTransformer<DemoAssociationModel>();
-        expect(transformer.selectFields, 'id,name,assoc:demos!assoc_id(id,name)');
+        expect(
+          transformer.selectFields,
+          'id,name,assoc:demos!assoc_id(id,name,age)',
+        );
       });
 
       test('association', () {
         final transformer = _buildTransformer<DemoNestedAssociationModel>();
         expect(
           transformer.selectFields,
-          'id,name,nested:demo_associations!nested_id(id,name,assoc:demos!assoc_id(id,name))',
+          'id,name,nested:demo_associations!nested_id(id,name,assoc:demos!assoc_id(id,name,age))',
         );
       });
     });
 
-    group('#select', skip: true, () {
-      test('no query', skip: true, () {});
-      group('with query', skip: true, () {
-        group('eq', skip: true, () {
-          test('by field', skip: true, () {});
+    group('#select', () {
+      test('no query', () {
+        final select = _buildTransformer<DemoModel>()
+            .select(_supabaseClient.from(DemoModelAdapter().tableName));
+
+        expect(select.query, 'select=id,name,age');
+      });
+      group('with query', () {
+        group('eq', () {
+          test('by field', () {
+            final query = Query.where('name', 'Jens');
+            final select = _buildTransformer<DemoModel>(query)
+                .select(_supabaseClient.from(DemoModelAdapter().tableName));
+
+            expect(select.query, 'select=id,name,age&name=eq.Jens');
+          });
+
           test('by association field', skip: true, () {});
         });
-        test('neq', skip: true, () {});
 
-        test('lt/gt/lte/gte', skip: true, () {});
-        test('contains', skip: true, () {});
-        test('does not contain', skip: true, () {});
+        test('neq', () {
+          final query = Query(
+            where: [Where('name', value: 'Jens', compare: Compare.notEqual)],
+          );
+          final select = _buildTransformer<DemoModel>(query)
+              .select(_supabaseClient.from(DemoModelAdapter().tableName));
+
+          expect(select.query, 'select=id,name,age&name=neq.Jens');
+        });
+
+        test('lt/gt/lte/gte', () {
+          final query = Query(
+            where: [
+              Where('age', value: '30', compare: Compare.lessThan),
+              Where('age', value: '18', compare: Compare.greaterThan),
+              Where('age', value: '25', compare: Compare.lessThanOrEqualTo),
+              Where('age', value: '21', compare: Compare.greaterThanOrEqualTo),
+            ],
+          );
+          final select = _buildTransformer<DemoModel>(query)
+              .select(_supabaseClient.from(DemoModelAdapter().tableName));
+
+          expect(
+            select.query,
+            'select=id,name,age&age=lt.30&age=gt.18&age=lte.25&age=gte.21',
+          );
+        });
+
+        test('contains', () {
+          final query = Query(
+            where: [Where('name', value: 'search', compare: Compare.contains)],
+          );
+          final select = _buildTransformer<DemoModel>(query)
+              .select(_supabaseClient.from(DemoModelAdapter().tableName));
+
+          expect(select.query, 'select=id,name,age&name=like.search');
+        });
+
+        test('does not contain', () {
+          final query = Query(
+            where: [
+              Where('name', value: 'search', compare: Compare.doesNotContain),
+            ],
+          );
+          final select = _buildTransformer<DemoModel>(query)
+              .select(_supabaseClient.from(DemoModelAdapter().tableName));
+
+          expect(select.query, 'select=id,name,age&name=not.like.search');
+        });
       });
     });
 
-    group('#applyProviderArgs', skip: true, () {});
+    group('#applyProviderArgs', () {
+      test('orderBy', () {
+        final query = Query(providerArgs: {'orderBy': 'name asc'});
+        final queryTransformer = _buildTransformer<DemoModel>(query);
+        final filterBuilder = queryTransformer
+            .select(_supabaseClient.from(DemoModelAdapter().tableName));
+        final transformBuilder =
+            queryTransformer.applyProviderArgs(filterBuilder);
+
+        expect(
+          transformBuilder.query,
+          'select=id,name,age&order=name.asc.nullslast',
+        );
+      });
+
+      test('orderBy with descending order', () {
+        final query = Query(providerArgs: {'orderBy': 'name desc'});
+        final queryTransformer = _buildTransformer<DemoModel>(query);
+        final filterBuilder = queryTransformer
+            .select(_supabaseClient.from(DemoModelAdapter().tableName));
+        final transformBuilder =
+            queryTransformer.applyProviderArgs(filterBuilder);
+
+        expect(
+          transformBuilder.query,
+          'select=id,name,age&order=name.desc.nullslast',
+        );
+      });
+
+      test('limit', () {
+        final query = Query(providerArgs: {'limit': 10});
+        final queryTransformer = _buildTransformer<DemoModel>(query);
+        final filterBuilder = queryTransformer
+            .select(_supabaseClient.from(DemoModelAdapter().tableName));
+        final transformBuilder =
+            queryTransformer.applyProviderArgs(filterBuilder);
+
+        expect(transformBuilder.query, 'select=id,name,age&limit=10');
+      });
+
+      test('limit with referenced table', skip: true, () {});
+
+      test('combined orderBy and limit', () {
+        final query =
+            Query(providerArgs: {'orderBy': 'name desc', 'limit': 20});
+        final queryTransformer = _buildTransformer<DemoModel>(query);
+        final filterBuilder = queryTransformer
+            .select(_supabaseClient.from(DemoModelAdapter().tableName));
+        final transformBuilder =
+            queryTransformer.applyProviderArgs(filterBuilder);
+
+        expect(
+          transformBuilder.query,
+          'select=id,name,age&order=name.desc.nullslast&limit=20',
+        );
+      });
+    });
 
     group('#destructureAssociationProperties', () {
       test('single association', () {
         final transformer = _buildTransformer<DemoAssociationModel>();
-        final result = transformer
-            .destructureAssociationProperties(transformer.adapter.fieldsToSupabaseColumns.values);
-        expect(result, containsAll(['id', 'name', 'assoc:demos!assoc_id(id,name)']));
+        final result = transformer.destructureAssociationProperties(
+          transformer.adapter.fieldsToSupabaseColumns.values,
+        );
+        expect(
+          result,
+          containsAll(['id', 'name', 'assoc:demos!assoc_id(id,name,age)']),
+        );
       });
 
       group('iterable association', skip: true, () {});
 
       test('nested association', () {
         final transformer = _buildTransformer<DemoNestedAssociationModel>();
-        final result = transformer
-            .destructureAssociationProperties(transformer.adapter.fieldsToSupabaseColumns.values);
+        final result = transformer.destructureAssociationProperties(
+          transformer.adapter.fieldsToSupabaseColumns.values,
+        );
         expect(
           result,
           containsAll([
             'id',
             'name',
-            'nested:demo_associations!nested_id(id,name,assoc:demos!assoc_id(id,name))',
+            'nested:demo_associations!nested_id(id,name,assoc:demos!assoc_id(id,name,age))',
           ]),
         );
       });


### PR DESCRIPTION
This PR implements most of the tests for the `QuerySupabaseTransformer`. (There are still some tests missing, where I am currently not sure how to properly implement them.)

I added an `age` field to the `DemoModel` class to use it for the lt/gt/lte/gte tests.

Because the `_uri` property of the `PostgrestBuilder` is private and therefore cannot be directly accessed, I created an extension on the `PostgrestBuilder` which returns the `URI` by using the `overrideSearchParams` method. While this works, I am open for suggestions to improving this!

