### PR TITLE
fix: add missing overrides to the supabase generator

### DIFF
--- a/packages/brick_supabase_generators/lib/src/supabase_deserialize.dart
+++ b/packages/brick_supabase_generators/lib/src/supabase_deserialize.dart
@@ -18,7 +18,7 @@ class SupabaseDeserialize extends SupabaseSerdesGenerator
     final config = (fields as SupabaseFields).config;
 
     return [
-      if (config?.tableName != null) "@override\nfinal supabaseTableName = '${config!.tableName}';",
+      "@override\nfinal supabaseTableName = ${config!.tableName == null ? 'null' : "'${config.tableName}'"};",
     ];
   }
 }

--- a/packages/brick_supabase_generators/lib/src/supabase_serialize.dart
+++ b/packages/brick_supabase_generators/lib/src/supabase_serialize.dart
@@ -44,7 +44,7 @@ class SupabaseSerialize extends SupabaseSerdesGenerator
         '@override\nfinal defaultToNull = ${config?.defaultToNull};',
       '@override\nfinal fieldsToSupabaseColumns = {${fieldsToColumns.join(',\n')}};',
       '@override\nfinal ignoreDuplicates = ${config?.ignoreDuplicates};',
-      if (config?.onConflict != null) "@override\nfinal onConflict = '${config?.onConflict}';",
+      "@override\nfinal onConflict = ${config?.onConflict == null ? 'null' : "'${config?.onConflict}'"};",
       '@override\nfinal uniqueFields = {${uniqueFields.map((u) => "'$u'").join(',\n')}};',
     ];
   }


### PR DESCRIPTION
This PR sits on top of https://github.com/GetDutchie/brick/pull/420, which fixed some generator issues as described in https://github.com/GetDutchie/brick/issues/416.

It specifically resolves the following errors:

The `Customer` model has no `onConflict` specified in the `SupabaseSerializable`, which results in the following runtime error because of the missing override:
```
lib/brick/adapters/customer_adapter.g.dart:102:7: Error: The non-abstract class 'CustomerAdapter' is missing implementations for these members:
 - SupabaseAdapter.onConflict
```
  
The `WindowType` model has no `SupabaseSerializable` specified (because there is no corresponding Supabase table, it is used inside a JSONB field), and therefore the `tableName` is null, which results in the following runtime error because of the missing override:

```
lib/brick/adapters/window_type_adapter.g.dart:98:7: Error: The non-abstract class 'WindowTypeAdapter' is missing implementations for these members:
 - SupabaseAdapter.supabaseTableName
```
---

I just noticed that the `supabaseTableName` is a non-nullable field on the `SupabaseAdapter`, which means this PR is not ready as it is. @tshedor how should we handle this?