### PR TITLE
fix(brick_offline_first): add toSupabase method to OfflineFirstSerdes

### DIFF
--- a/packages/brick_offline_first/lib/src/models/offline_first_serdes.dart
+++ b/packages/brick_offline_first/lib/src/models/offline_first_serdes.dart
@@ -19,6 +19,9 @@ abstract class OfflineFirstSerdes<RemoteSerializeType, SqliteSerializeType> {
   /// Pre-serialization to JSON. Must be digestible by `jsonEncode`.
   RemoteSerializeType? toRest() => null;
 
+  /// Pre-serialization to JSON. Must be digestible by `jsonEncode`.
+  RemoteSerializeType? toSupabase() => null;
+
   /// Must be one of the following: `bool`, `DateTime`, `double`, `int`, `num`, `String`,
   /// or another `Iterable` digestible by `jsonEncode`.
   ///


### PR DESCRIPTION
This adds the missing `toSupabase` method to the `OfflineFirstSerdes`, which is needed to create `OfflineFirstSerdes` for Supabase.