### PR TITLE
feat(offline_first_with_rest): add request/response callbacks to the RestOfflineQueueClient

### DIFF
--- a/docs/offline_first/offline_first_with_graphql_repository.md
+++ b/docs/offline_first/offline_first_with_graphql_repository.md
@@ -17,7 +17,12 @@ To cache outbound requests, apply `GraphqlOfflineQueueLink` in your GraphqlProvi
 ```dart
 GraphqlProvider(
   link: Link.from([
-    GraphqlOfflineQueueLink(GraphqlRequestSqliteCacheManager('myAppRequestQueue.sqlite')),
+    GraphqlOfflineQueueLink(
+      GraphqlRequestSqliteCacheManager('myAppRequestQueue.sqlite'),
+      // Optionally specify callbacks for queue retries and errors
+      onReattemptableResponse: onReattemptableResponse,
+      onRequestError: onRequestError,
+    ),
     HttpLink(endpoint)
   ]),
 );

--- a/docs/offline_first/offline_first_with_graphql_repository.md
+++ b/docs/offline_first/offline_first_with_graphql_repository.md
@@ -20,7 +20,7 @@ GraphqlProvider(
     GraphqlOfflineQueueLink(
       GraphqlRequestSqliteCacheManager('myAppRequestQueue.sqlite'),
       // Optionally specify callbacks for queue retries and errors
-      onReattemptableResponse: onReattemptableResponse,
+      onReattempt: onReattempt,
       onRequestException: onRequestException,
     ),
     HttpLink(endpoint)

--- a/docs/offline_first/offline_first_with_graphql_repository.md
+++ b/docs/offline_first/offline_first_with_graphql_repository.md
@@ -21,7 +21,7 @@ GraphqlProvider(
       GraphqlRequestSqliteCacheManager('myAppRequestQueue.sqlite'),
       // Optionally specify callbacks for queue retries and errors
       onReattemptableResponse: onReattemptableResponse,
-      onRequestError: onRequestError,
+      onRequestException: onRequestException,
     ),
     HttpLink(endpoint)
   ]),

--- a/docs/offline_first/offline_queue.md
+++ b/docs/offline_first/offline_queue.md
@@ -18,3 +18,12 @@ final link = GraphqlOfflineQueueLink(
 ![OfflineQueue logic flow](https://user-images.githubusercontent.com/865897/72175823-f44a3580-3391-11ea-8961-bbeccd74fe7b.jpg)
 
 !> The queue ignores requests that are not `DELETE`, `PATCH`, `POST`, and `PUT` for REST. In GraphQL, `query` and `subscription` operations are ignored. Fetching requests are not worth tracking as the caller may have been disposed by the time the app regains connectivity.
+
+## Queue Processing Callbacks
+
+For tracking the status of queued request processing, the constructor of `GraphqlOfflineQueueLink` and `RestOfflineQueueClient` accept callback functions, which are triggered for specific events when processing queued requests:
+
+- `onRequestError`: Invoked when a request encounters an exception during execution (e.g. a `SocketException`). The function receives both the request and an object containing the thrown exception.
+- `onReattemptableResponse`: Invoked when a request results in a response with a status code listed in the `reattemptForStatusCodes` list. The function receives the request and the response HTTP status code.
+
+These callbacks provide practical ways to detect the state of the queue (e.g. if the client is offline, the queue is being processed or being blocked in case of serial processing). For more details, refer to the [discussion on this topic](https://github.com/GetDutchie/brick/issues/393).

--- a/docs/offline_first/offline_queue.md
+++ b/docs/offline_first/offline_queue.md
@@ -23,7 +23,7 @@ final link = GraphqlOfflineQueueLink(
 
 For tracking the status of queued requests, the `GraphqlOfflineQueueLink` and `RestOfflineQueueClient` constructors accept callback functions which are triggered for specific events:
 
-- `onRequestError`: Invoked when a request encounters an exception during execution (e.g. a `SocketException`). The function receives both the request and an object containing the thrown exception.
+- `onRequestException`: Invoked when a request encounters an exception during execution (e.g. a `SocketException`). The function receives both the request and an object containing the thrown exception.
 - `onReattemptableResponse`: Invoked when a request will be retried. For REST, this is when the response has a status code listed in the `reattemptForStatusCodes` list.
 
 These callbacks provide practical ways to detect the state of the queue (e.g. if the client is offline, the queue is being processed, or the queue is blocked during serial processing). For more, refer to the [discussion on this topic](https://github.com/GetDutchie/brick/issues/393).

--- a/docs/offline_first/offline_queue.md
+++ b/docs/offline_first/offline_queue.md
@@ -24,6 +24,6 @@ final link = GraphqlOfflineQueueLink(
 For tracking the status of queued requests, the `GraphqlOfflineQueueLink` and `RestOfflineQueueClient` constructors accept callback functions which are triggered for specific events:
 
 - `onRequestException`: Invoked when a request encounters an exception during execution (e.g. a `SocketException`). The function receives both the request and an object containing the thrown exception.
-- `onReattemptableResponse`: Invoked when a request will be retried. For REST, this is when the response has a status code listed in the `reattemptForStatusCodes` list.
+- `onReattempt`: Invoked when a request will be retried. For REST, this is when the response has a status code listed in the `reattemptForStatusCodes` list.
 
 These callbacks provide practical ways to detect the state of the queue (e.g. if the client is offline, the queue is being processed, or the queue is blocked during serial processing). For more, refer to the [discussion on this topic](https://github.com/GetDutchie/brick/issues/393).

--- a/docs/offline_first/offline_queue.md
+++ b/docs/offline_first/offline_queue.md
@@ -21,9 +21,9 @@ final link = GraphqlOfflineQueueLink(
 
 ## Queue Processing Callbacks
 
-For tracking the status of queued request processing, the constructor of `GraphqlOfflineQueueLink` and `RestOfflineQueueClient` accept callback functions, which are triggered for specific events when processing queued requests:
+For tracking the status of queued requests, the `GraphqlOfflineQueueLink` and `RestOfflineQueueClient` constructors accept callback functions which are triggered for specific events:
 
 - `onRequestError`: Invoked when a request encounters an exception during execution (e.g. a `SocketException`). The function receives both the request and an object containing the thrown exception.
-- `onReattemptableResponse`: Invoked when a request results in a response with a status code listed in the `reattemptForStatusCodes` list. The function receives the request and the response HTTP status code.
+- `onReattemptableResponse`: Invoked when a request will be retried. For REST, this is when the response has a status code listed in the `reattemptForStatusCodes` list.
 
-These callbacks provide practical ways to detect the state of the queue (e.g. if the client is offline, the queue is being processed or being blocked in case of serial processing). For more details, refer to the [discussion on this topic](https://github.com/GetDutchie/brick/issues/393).
+These callbacks provide practical ways to detect the state of the queue (e.g. if the client is offline, the queue is being processed, or the queue is blocked during serial processing). For more, refer to the [discussion on this topic](https://github.com/GetDutchie/brick/issues/393).

--- a/packages/brick_offline_first_with_graphql/CHANGELOG.md
+++ b/packages/brick_offline_first_with_graphql/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 3.2.0
+
 ## 3.1.1
 
 - Loosen constraints for `gql`, `gql_exec`, and `gql_link`

--- a/packages/brick_offline_first_with_graphql/CHANGELOG.md
+++ b/packages/brick_offline_first_with_graphql/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 3.2.0
 
+- Add optional `onRequestException` callback function to `GraphqlOfflineQueueLink`
+- Add optional `onReattempt` callback function to `RestOfflineQueueClient`
+
 ## 3.1.1
 
 - Loosen constraints for `gql`, `gql_exec`, and `gql_link`

--- a/packages/brick_offline_first_with_graphql/README.md
+++ b/packages/brick_offline_first_with_graphql/README.md
@@ -15,7 +15,7 @@ GraphqlProvider(
       GraphqlRequestSqliteCacheManager('myAppRequestQueue.sqlite'),
       // Optionally specify callbacks for queue retries and errors
       onReattemptableResponse: onReattemptableResponse,
-      onRequestError: onRequestError,
+      onRequestException: onRequestException,
     ),
     HttpLink(endpoint)
   ]),

--- a/packages/brick_offline_first_with_graphql/README.md
+++ b/packages/brick_offline_first_with_graphql/README.md
@@ -11,7 +11,12 @@ To cache outbound requests, apply `GraphqlOfflineQueueLink` in your GraphqlProvi
 ```dart
 GraphqlProvider(
   link: Link.from([
-    GraphqlOfflineQueueLink(GraphqlRequestSqliteCacheManager('myAppRequestQueue.sqlite')),
+    GraphqlOfflineQueueLink(
+      GraphqlRequestSqliteCacheManager('myAppRequestQueue.sqlite'),
+      // Optionally specify callbacks for queue retries and errors
+      onReattemptableResponse: onReattemptableResponse,
+      onRequestError: onRequestError,
+    ),
     HttpLink(endpoint)
   ]),
 );
@@ -43,9 +48,9 @@ Due to [an open analyzer bug](https://github.com/dart-lang/sdk/issues/38309), a 
 
 ### Field Types
 
-* Any unsupported field types from `GraphqlProvider` or `SqliteProvider`
-* Future iterables of future models (i.e. `Future<List<Future<Model>>>`.
+- Any unsupported field types from `GraphqlProvider` or `SqliteProvider`
+- Future iterables of future models (i.e. `Future<List<Future<Model>>>`.
 
 ### Configuration
 
-* `@OfflineFirst(where:` only supports extremely simple renames. Multiple `where` keys (`OfflineFirst(where: {'id': 'data["id"]', 'otherVar': 'data["otherVar"]'})`) or nested properties (`OfflineFirst(where: {'id': 'data["subfield"]["id"]})`) will be ignored. Be sure to use `@Graphql(name:)` to rename the generated document field.
+- `@OfflineFirst(where:` only supports extremely simple renames. Multiple `where` keys (`OfflineFirst(where: {'id': 'data["id"]', 'otherVar': 'data["otherVar"]'})`) or nested properties (`OfflineFirst(where: {'id': 'data["subfield"]["id"]})`) will be ignored. Be sure to use `@Graphql(name:)` to rename the generated document field.

--- a/packages/brick_offline_first_with_graphql/README.md
+++ b/packages/brick_offline_first_with_graphql/README.md
@@ -14,7 +14,7 @@ GraphqlProvider(
     GraphqlOfflineQueueLink(
       GraphqlRequestSqliteCacheManager('myAppRequestQueue.sqlite'),
       // Optionally specify callbacks for queue retries and errors
-      onReattemptableResponse: onReattemptableResponse,
+      onReattempt: onReattempt,
       onRequestException: onRequestException,
     ),
     HttpLink(endpoint)

--- a/packages/brick_offline_first_with_graphql/lib/src/graphql_offline_queue_link.dart
+++ b/packages/brick_offline_first_with_graphql/lib/src/graphql_offline_queue_link.dart
@@ -56,8 +56,9 @@ class GraphqlOfflineQueueLink extends Link {
         // request was successfully sent and can be removed
         _logger.finest('removing from queue: ${cacheItem.toSqlite()}');
         await cacheItem.delete(db);
-      } else {
-        onReattemptableResponse?.call(request, response.response['statusCode'] as int);
+      } else if (response.response.containsKey('statusCode') &&
+          response.response['statusCode'] is int) {
+        onReattemptableResponse?.call(request, response.response['statusCode']);
       }
       final db = await requestManager.getDb();
       await cacheItem.unlock(db);

--- a/packages/brick_offline_first_with_graphql/lib/src/graphql_offline_queue_link.dart
+++ b/packages/brick_offline_first_with_graphql/lib/src/graphql_offline_queue_link.dart
@@ -16,14 +16,14 @@ class GraphqlOfflineQueueLink extends Link {
   final GraphqlRequestSqliteCacheManager requestManager;
 
   /// A callback triggered when a request failed, but will be reattempted.
-  final void Function(Request request)? onReattemptableResponse;
+  final void Function(Request request)? onReattempt;
 
   /// A callback triggered when a request throws an exception during execution.
   final void Function(Request request, Object error)? onRequestException;
 
   GraphqlOfflineQueueLink(
     this.requestManager, {
-    this.onReattemptableResponse,
+    this.onReattempt,
     this.onRequestException,
   }) : _logger = Logger('GraphqlOfflineQueueLink#${requestManager.databaseName}');
 
@@ -60,7 +60,7 @@ class GraphqlOfflineQueueLink extends Link {
         onRequestException?.call(request, response.errors!);
       }
 
-      onReattemptableResponse?.call(request);
+      onReattempt?.call(request);
       final db = await requestManager.getDb();
       await cacheItem.unlock(db);
 

--- a/packages/brick_offline_first_with_graphql/pubspec.yaml
+++ b/packages/brick_offline_first_with_graphql/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_offline_f
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 3.1.1
+version: 3.2.0
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/brick_offline_first_with_graphql/test/graphql_offline_queue_link_test.dart
+++ b/packages/brick_offline_first_with_graphql/test/graphql_offline_queue_link_test.dart
@@ -152,14 +152,14 @@ void main() {
       });
     });
 
-    group('#onReattemptableResponse', () {
+    group('#onReattempt', () {
       test('callback is triggered when request retries', () async {
         Request? capturedRequest;
 
         final mockLink = stubGraphqlLink({}, errors: ['Test failure']);
         final client = GraphqlOfflineQueueLink(
           requestManager,
-          onReattemptableResponse: (r) => capturedRequest = r,
+          onReattempt: (r) => capturedRequest = r,
         ).concat(mockLink);
 
         final mutationRequest = Request(
@@ -180,7 +180,7 @@ void main() {
         final mockLink = MockLink();
         final client = GraphqlOfflineQueueLink(
           requestManager,
-          onReattemptableResponse: (r) => capturedRequest = r,
+          onReattempt: (r) => capturedRequest = r,
         ).concat(mockLink);
 
         when(

--- a/packages/brick_offline_first_with_graphql/test/graphql_offline_queue_link_test.dart
+++ b/packages/brick_offline_first_with_graphql/test/graphql_offline_queue_link_test.dart
@@ -201,17 +201,17 @@ void main() {
       });
     });
 
-    group('#onRequestError', () {
+    group('#onRequestException', () {
       test('callback is triggered for a failed response', () async {
         Request? capturedRequest;
-        Object? capturedError;
+        Object? capturedonException;
 
         final mockLink = stubGraphqlLink({}, errors: ['Test failure']);
         final client = GraphqlOfflineQueueLink(
           requestManager,
-          onRequestError: (r, err) {
-            capturedRequest = r;
-            capturedError = err;
+          onRequestException: (request, exception) {
+            capturedRequest = request;
+            capturedonException = exception;
           },
         ).concat(mockLink);
 
@@ -224,20 +224,20 @@ void main() {
         await client.request(mutationRequest).first;
 
         expect(capturedRequest, isNotNull);
-        expect(capturedError, isNotNull);
-        expect(capturedError.toString(), contains('Test failure'));
+        expect(capturedonException, isNotNull);
+        expect(capturedonException.toString(), contains('Test failure'));
       });
 
       test('callback is not triggered on successful response', () async {
         Request? capturedRequest;
-        Object? capturedError;
+        Object? capturedException;
 
         final mockLink = MockLink();
         final client = GraphqlOfflineQueueLink(
           requestManager,
-          onRequestError: (r, err) {
-            capturedRequest = r;
-            capturedError = err;
+          onRequestException: (request, exception) {
+            capturedRequest = request;
+            capturedException = exception;
           },
         ).concat(mockLink);
 
@@ -256,7 +256,7 @@ void main() {
         );
 
         expect(capturedRequest, isNull);
-        expect(capturedError, isNull);
+        expect(capturedException, isNull);
       });
     });
 

--- a/packages/brick_offline_first_with_rest/CHANGELOG.md
+++ b/packages/brick_offline_first_with_rest/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 3.2.0
+
 ## 3.1.0
 
 - Expose offline queue functionality in `offline_queue.dart`

--- a/packages/brick_offline_first_with_rest/CHANGELOG.md
+++ b/packages/brick_offline_first_with_rest/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 3.2.0
 
+- Add optional `onRequestException` callback function to `RestOfflineQueueClient`
+- Add optional `onReattempt` callback function to `RestOfflineQueueClient`
+
 ## 3.1.0
 
 - Expose offline queue functionality in `offline_queue.dart`

--- a/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
@@ -47,6 +47,13 @@ abstract class OfflineFirstWithRestRepository
     /// This property is forwarded to `RestOfflineQueueClient` and assumes
     /// its defaults
     List<int>? reattemptForStatusCodes,
+
+    /// This property is forwarded to `RestOfflineRequestQueue`.
+    void Function(http.Request request, http.StreamedResponse response)?
+        onReattemptableResponse,
+
+    /// This property is forwarded to `RestOfflineRequestQueue`.
+    void Function(http.Request, Object)? onRequestError,
     required RestProvider restProvider,
     required super.sqliteProvider,
   })  : remoteProvider = restProvider,
@@ -57,6 +64,8 @@ abstract class OfflineFirstWithRestRepository
       restProvider.client,
       offlineQueueManager,
       reattemptForStatusCodes: reattemptForStatusCodes,
+      onRequestError: onRequestError,
+      onReattemptableResponse: onReattemptableResponse,
     );
     offlineRequestQueue = RestOfflineRequestQueue(
       client: remoteProvider.client as RestOfflineQueueClient,

--- a/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
@@ -73,9 +73,9 @@ abstract class OfflineFirstWithRestRepository
     remoteProvider.client = RestOfflineQueueClient(
       restProvider.client,
       offlineQueueManager,
-      reattemptForStatusCodes: reattemptForStatusCodes,
-      onRequestError: onRequestError,
       onReattemptableResponse: onReattemptableResponse,
+      onRequestError: onRequestError,
+      reattemptForStatusCodes: reattemptForStatusCodes,
     );
     offlineRequestQueue = RestOfflineRequestQueue(
       client: remoteProvider.client as RestOfflineQueueClient,

--- a/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
@@ -30,17 +30,6 @@ abstract class OfflineFirstWithRestRepository
   @protected
   late RestOfflineRequestQueue offlineRequestQueue;
 
-  /// A callback triggered when the response of a request has a status code
-  /// which is present in the [reattemptForStatusCodes] list.
-  ///
-  /// Forwarded to [RestOfflineQueueClient].
-  void Function(http.Request request, int statusCode)? onReattempt;
-
-  /// A callback triggered when a request throws an exception during execution.
-  ///
-  /// Forwarded to [RestOfflineQueueClient].
-  void Function(http.Request, Object)? onRequestException;
-
   OfflineFirstWithRestRepository({
     super.autoHydrate,
     super.loggerName,
@@ -59,11 +48,16 @@ abstract class OfflineFirstWithRestRepository
     /// its defaults
     List<int>? reattemptForStatusCodes,
 
-    /// This property is forwarded to `RestOfflineQueueClient`.
-    this.onReattempt,
+    /// A callback triggered when the response of a request has a status code
+    /// which is present in the [reattemptForStatusCodes] list.
+    ///
+    /// Forwarded to [RestOfflineQueueClient].
+    void Function(http.Request request, int statusCode)? onReattempt,
 
-    /// This property is forwarded to `RestOfflineQueueClient`.
-    this.onRequestException,
+    /// A callback triggered when a request throws an exception during execution.
+    ///
+    /// Forwarded to [RestOfflineQueueClient].
+    void Function(http.Request, Object)? onRequestException,
     required RestProvider restProvider,
     required super.sqliteProvider,
   })  : remoteProvider = restProvider,

--- a/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
@@ -34,7 +34,7 @@ abstract class OfflineFirstWithRestRepository
   /// which is present in the [reattemptForStatusCodes] list.
   ///
   /// Forwarded to [RestOfflineQueueClient].
-  void Function(http.Request request, int statusCode)? onReattemptableResponse;
+  void Function(http.Request request, int statusCode)? onReattempt;
 
   /// A callback triggered when a request throws an exception during execution.
   ///
@@ -60,7 +60,7 @@ abstract class OfflineFirstWithRestRepository
     List<int>? reattemptForStatusCodes,
 
     /// This property is forwarded to `RestOfflineQueueClient`.
-    this.onReattemptableResponse,
+    this.onReattempt,
 
     /// This property is forwarded to `RestOfflineQueueClient`.
     this.onRequestException,
@@ -73,7 +73,7 @@ abstract class OfflineFirstWithRestRepository
     remoteProvider.client = RestOfflineQueueClient(
       restProvider.client,
       offlineQueueManager,
-      onReattemptableResponse: onReattemptableResponse,
+      onReattempt: onReattempt,
       onRequestException: onRequestException,
       reattemptForStatusCodes: reattemptForStatusCodes,
     );

--- a/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
@@ -34,7 +34,7 @@ abstract class OfflineFirstWithRestRepository
   /// which is present in the [reattemptForStatusCodes] list.
   ///
   /// Forwarded to [RestOfflineQueueClient].
-  void Function(http.Request request, http.StreamedResponse response)? onReattemptableResponse;
+  void Function(http.Request request, int statusCode)? onReattemptableResponse;
 
   /// A callback triggered when a request throws an exception during execution.
   ///

--- a/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
@@ -39,7 +39,7 @@ abstract class OfflineFirstWithRestRepository
   /// A callback triggered when a request throws an exception during execution.
   ///
   /// Forwarded to [RestOfflineQueueClient].
-  void Function(http.Request, Object)? onRequestError;
+  void Function(http.Request, Object)? onRequestException;
 
   OfflineFirstWithRestRepository({
     super.autoHydrate,
@@ -63,7 +63,7 @@ abstract class OfflineFirstWithRestRepository
     this.onReattemptableResponse,
 
     /// This property is forwarded to `RestOfflineQueueClient`.
-    this.onRequestError,
+    this.onRequestException,
     required RestProvider restProvider,
     required super.sqliteProvider,
   })  : remoteProvider = restProvider,
@@ -74,7 +74,7 @@ abstract class OfflineFirstWithRestRepository
       restProvider.client,
       offlineQueueManager,
       onReattemptableResponse: onReattemptableResponse,
-      onRequestError: onRequestError,
+      onRequestException: onRequestException,
       reattemptForStatusCodes: reattemptForStatusCodes,
     );
     offlineRequestQueue = RestOfflineRequestQueue(

--- a/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
@@ -30,6 +30,17 @@ abstract class OfflineFirstWithRestRepository
   @protected
   late RestOfflineRequestQueue offlineRequestQueue;
 
+  /// A callback triggered when the response of a request has a status code
+  /// which is present in the [reattemptForStatusCodes] list.
+  ///
+  /// Forwarded to [RestOfflineQueueClient].
+  void Function(http.Request request, http.StreamedResponse response)? onReattemptableResponse;
+
+  /// A callback triggered when a request throws an exception during execution.
+  ///
+  /// Forwarded to [RestOfflineQueueClient].
+  void Function(http.Request, Object)? onRequestError;
+
   OfflineFirstWithRestRepository({
     super.autoHydrate,
     super.loggerName,
@@ -49,11 +60,10 @@ abstract class OfflineFirstWithRestRepository
     List<int>? reattemptForStatusCodes,
 
     /// This property is forwarded to `RestOfflineRequestQueue`.
-    void Function(http.Request request, http.StreamedResponse response)?
-        onReattemptableResponse,
+    this.onReattemptableResponse,
 
     /// This property is forwarded to `RestOfflineRequestQueue`.
-    void Function(http.Request, Object)? onRequestError,
+    this.onRequestError,
     required RestProvider restProvider,
     required super.sqliteProvider,
   })  : remoteProvider = restProvider,

--- a/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
@@ -59,10 +59,10 @@ abstract class OfflineFirstWithRestRepository
     /// its defaults
     List<int>? reattemptForStatusCodes,
 
-    /// This property is forwarded to `RestOfflineRequestQueue`.
+    /// This property is forwarded to `RestOfflineQueueClient`.
     this.onReattemptableResponse,
 
-    /// This property is forwarded to `RestOfflineRequestQueue`.
+    /// This property is forwarded to `RestOfflineQueueClient`.
     this.onRequestError,
     required RestProvider restProvider,
     required super.sqliteProvider,

--- a/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
@@ -17,8 +17,6 @@ class RestOfflineQueueClient extends http.BaseClient {
   /// as detailed by [the Dart team](https://github.com/dart-lang/http/blob/378179845420caafbf7a34d47b9c22104753182a/README.md#using)
   final http.Client _inner;
 
-  final RequestSqliteCacheManager<http.Request> requestManager;
-
   /// A callback triggered when the response of a request has a status code
   /// which is present in the [reattemptForStatusCodes] list.
   void Function(http.Request request, int statusCode)? onReattemptableResponse;
@@ -27,6 +25,8 @@ class RestOfflineQueueClient extends http.BaseClient {
   ///
   /// `SocketException`s (errors thrown due to missing connectivity) will also be forwarded to this callback.
   void Function(http.Request request, Object error)? onRequestError;
+
+  final RequestSqliteCacheManager<http.Request> requestManager;
 
   /// If the response returned from the client is one of these error codes, the request
   /// **will not** be removed from the queue. For example, if the result of a request produces a
@@ -107,7 +107,7 @@ class RestOfflineQueueClient extends http.BaseClient {
           _logger.finest('removing from queue: ${cacheItem.toSqlite()}');
           await cacheItem.delete(db);
         } else if (onReattemptableResponse != null) {
-          _logger.finer(
+          _logger.finest(
             'request failed, will be reattempted: ${cacheItem.toSqlite()}',
           );
           onReattemptableResponse?.call(request, resp.statusCode);

--- a/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
@@ -24,7 +24,7 @@ class RestOfflineQueueClient extends http.BaseClient {
   /// A callback triggered when a request throws an exception during execution.
   ///
   /// `SocketException`s (errors thrown due to missing connectivity) will also be forwarded to this callback.
-  void Function(http.Request request, Object error)? onRequestError;
+  void Function(http.Request request, Object error)? onRequestException;
 
   final RequestSqliteCacheManager<http.Request> requestManager;
 
@@ -47,7 +47,7 @@ class RestOfflineQueueClient extends http.BaseClient {
     this._inner,
     this.requestManager, {
     this.onReattemptableResponse,
-    this.onRequestError,
+    this.onRequestException,
     List<int>? reattemptForStatusCodes,
 
     /// Any request URI that begins with one of these paths will not be
@@ -117,7 +117,7 @@ class RestOfflineQueueClient extends http.BaseClient {
       return resp;
     } catch (e) {
       // e.g. SocketExceptions will be caught here
-      onRequestError?.call(request, e);
+      onRequestException?.call(request, e);
       _logger.warning('#send: $e');
     } finally {
       // unlock the request for a later a reattempt

--- a/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
@@ -21,7 +21,7 @@ class RestOfflineQueueClient extends http.BaseClient {
 
   /// A callback triggered when the response of a request has a status code
   /// which is present in the [reattemptForStatusCodes] list.
-  void Function(http.Request request, http.StreamedResponse response)? onReattemptableResponse;
+  void Function(http.Request request, int statusCode)? onReattemptableResponse;
 
   /// A callback triggered when a request throws an exception during execution.
   ///
@@ -110,7 +110,7 @@ class RestOfflineQueueClient extends http.BaseClient {
           _logger.finer(
             'request failed, will be reattempted: ${cacheItem.toSqlite()}',
           );
-          onReattemptableResponse?.call(request, resp);
+          onReattemptableResponse?.call(request, resp.statusCode);
         }
       }
 

--- a/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
@@ -24,6 +24,8 @@ class RestOfflineQueueClient extends http.BaseClient {
   void Function(http.Request request, http.StreamedResponse response)? onReattemptableResponse;
 
   /// A callback triggered when a request throws an exception during execution.
+  ///
+  /// `SocketException`s (errors thrown due to missing connectivity) will also be forwarded to this callback.
   void Function(http.Request request, Object error)? onRequestError;
 
   /// If the response returned from the client is one of these error codes, the request
@@ -118,7 +120,7 @@ class RestOfflineQueueClient extends http.BaseClient {
       onRequestError?.call(request, e);
       _logger.warning('#send: $e');
     } finally {
-      // unlock the request which results in a reattempt
+      // unlock the request for a later a reattempt
       final db = await requestManager.getDb();
       await cacheItem.unlock(db);
     }

--- a/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
@@ -19,7 +19,7 @@ class RestOfflineQueueClient extends http.BaseClient {
 
   /// A callback triggered when the response of a request has a status code
   /// which is present in the [reattemptForStatusCodes] list.
-  void Function(http.Request request, int statusCode)? onReattemptableResponse;
+  void Function(http.Request request, int statusCode)? onReattempt;
 
   /// A callback triggered when a request throws an exception during execution.
   ///
@@ -46,7 +46,7 @@ class RestOfflineQueueClient extends http.BaseClient {
   RestOfflineQueueClient(
     this._inner,
     this.requestManager, {
-    this.onReattemptableResponse,
+    this.onReattempt,
     this.onRequestException,
     List<int>? reattemptForStatusCodes,
 
@@ -106,11 +106,11 @@ class RestOfflineQueueClient extends http.BaseClient {
           // request was successfully sent and can be removed
           _logger.finest('removing from queue: ${cacheItem.toSqlite()}');
           await cacheItem.delete(db);
-        } else if (onReattemptableResponse != null) {
+        } else if (onReattempt != null) {
           _logger.finest(
             'request failed, will be reattempted: ${cacheItem.toSqlite()}',
           );
-          onReattemptableResponse?.call(request, resp.statusCode);
+          onReattempt?.call(request, resp.statusCode);
         }
       }
 

--- a/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_queue/rest_offline_queue_client.dart
@@ -21,8 +21,7 @@ class RestOfflineQueueClient extends http.BaseClient {
 
   /// A callback triggered when the response of a request has a status code
   /// which is present in the [reattemptForStatusCodes] list.
-  void Function(http.Request request, http.StreamedResponse response)?
-      onReattemptableResponse;
+  void Function(http.Request request, http.StreamedResponse response)? onReattemptableResponse;
 
   /// A callback triggered when a request throws an exception during execution.
   void Function(http.Request request, Object error)? onRequestError;
@@ -105,9 +104,10 @@ class RestOfflineQueueClient extends http.BaseClient {
           // request was successfully sent and can be removed
           _logger.finest('removing from queue: ${cacheItem.toSqlite()}');
           await cacheItem.delete(db);
-        } else {
-          _logger.finest(
-              'request failed, will be reattempted: ${cacheItem.toSqlite()}');
+        } else if (onReattemptableResponse != null) {
+          _logger.finer(
+            'request failed, will be reattempted: ${cacheItem.toSqlite()}',
+          );
           onReattemptableResponse?.call(request, resp);
         }
       }

--- a/packages/brick_offline_first_with_rest/pubspec.yaml
+++ b/packages/brick_offline_first_with_rest/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_offline_f
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 3.1.0
+version: 3.1.1
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/brick_offline_first_with_rest/test/offline_queue/rest_offline_queue_client_test.dart
+++ b/packages/brick_offline_first_with_rest/test/offline_queue/rest_offline_queue_client_test.dart
@@ -1,5 +1,8 @@
+import 'dart:io';
+
 import 'package:brick_offline_first_with_rest/src/offline_queue/rest_offline_queue_client.dart';
 import 'package:brick_offline_first_with_rest/src/offline_queue/rest_request_sqlite_cache_manager.dart';
+import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 import 'package:test/test.dart';
@@ -186,6 +189,94 @@ void main() {
 
           await client.patch(Uri.parse('http://0.0.0.0:3000'), body: 'new record');
           expect(await requestManager.unprocessedRequests(), hasLength(4));
+        });
+
+        test('onReattemptableResponse callback is triggered for reattemptable status code',
+            () async {
+          http.Request? capturedRequest;
+          int? capturedStatusCode;
+
+          final inner = stubResult(statusCode: 429);
+          final client = RestOfflineQueueClient(
+            inner,
+            requestManager,
+            reattemptForStatusCodes: [429],
+            onReattemptableResponse: (request, statusCode) {
+              capturedRequest = request;
+              capturedStatusCode = statusCode;
+            },
+          );
+
+          final uri = Uri.parse('http://0.0.0.0:3000');
+
+          await client.post(uri, body: 'test');
+
+          expect(capturedRequest?.method, equals('POST'));
+          expect(capturedRequest?.url, equals(uri));
+          expect(capturedStatusCode, equals(429));
+        });
+
+        test('onReattemptableResponse is not triggered for non-reattemptable status code',
+            () async {
+          bool callbackTriggered = false;
+
+          final inner = stubResult(statusCode: 404);
+          final client = RestOfflineQueueClient(
+            inner,
+            requestManager,
+            reattemptForStatusCodes: [429],
+            onReattemptableResponse: (request, statusCode) {
+              callbackTriggered = true;
+            },
+          );
+
+          await client.post(Uri.parse('http://0.0.0.0:3000'), body: 'test');
+
+          expect(callbackTriggered, isFalse);
+        });
+
+        test('onRequestError callback is triggered for SocketException', () async {
+          http.Request? capturedRequest;
+          Object? capturedError;
+
+          final inner = MockClient((req) async {
+            throw SocketException('test error');
+          });
+
+          final client = RestOfflineQueueClient(
+            inner,
+            requestManager,
+            onRequestError: (request, error) {
+              capturedRequest = request;
+              capturedError = error;
+            },
+          );
+
+          final uri = Uri.parse('http://0.0.0.0:3000');
+
+          await client.post(uri, body: 'test');
+
+          expect(capturedRequest?.method, equals('POST'));
+          expect(capturedRequest?.url, equals(uri));
+          expect(capturedError, isA<SocketException>());
+          expect((capturedError as SocketException).message, equals('test error'));
+        });
+
+        test('onRequestError is not triggered for successful request', () async {
+          bool callbackTriggered = false;
+
+          final inner = stubResult(statusCode: 200);
+          final client = RestOfflineQueueClient(
+            inner,
+            requestManager,
+            onRequestError: (request, error) {
+              callbackTriggered = true;
+            },
+          );
+
+          await client.post(Uri.parse('http://0.0.0.0:3000'), body: 'test');
+
+          expect(callbackTriggered, isFalse);
         });
       });
     });

--- a/packages/brick_offline_first_with_rest/test/offline_queue/rest_offline_queue_client_test.dart
+++ b/packages/brick_offline_first_with_rest/test/offline_queue/rest_offline_queue_client_test.dart
@@ -191,8 +191,7 @@ void main() {
           expect(await requestManager.unprocessedRequests(), hasLength(4));
         });
 
-        test('onReattemptableResponse callback is triggered for reattemptable status code',
-            () async {
+        test('onReattempt callback is triggered for reattemptable status code', () async {
           http.Request? capturedRequest;
           int? capturedStatusCode;
 
@@ -201,7 +200,7 @@ void main() {
             inner,
             requestManager,
             reattemptForStatusCodes: [429],
-            onReattemptableResponse: (request, statusCode) {
+            onReattempt: (request, statusCode) {
               capturedRequest = request;
               capturedStatusCode = statusCode;
             },
@@ -216,8 +215,7 @@ void main() {
           expect(capturedStatusCode, equals(429));
         });
 
-        test('onReattemptableResponse is not triggered for non-reattemptable status code',
-            () async {
+        test('onReattempt is not triggered for non-reattemptable status code', () async {
           bool callbackTriggered = false;
 
           final inner = stubResult(statusCode: 404);
@@ -225,7 +223,7 @@ void main() {
             inner,
             requestManager,
             reattemptForStatusCodes: [429],
-            onReattemptableResponse: (request, statusCode) {
+            onReattempt: (request, statusCode) {
               callbackTriggered = true;
             },
           );

--- a/packages/brick_offline_first_with_rest/test/offline_queue/rest_offline_queue_client_test.dart
+++ b/packages/brick_offline_first_with_rest/test/offline_queue/rest_offline_queue_client_test.dart
@@ -235,9 +235,9 @@ void main() {
           expect(callbackTriggered, isFalse);
         });
 
-        test('onRequestError callback is triggered for SocketException', () async {
+        test('onRequestException callback is triggered for SocketException', () async {
           http.Request? capturedRequest;
-          Object? capturedError;
+          Object? capturedException;
 
           final inner = MockClient((req) async {
             throw SocketException('test error');
@@ -246,9 +246,9 @@ void main() {
           final client = RestOfflineQueueClient(
             inner,
             requestManager,
-            onRequestError: (request, error) {
+            onRequestException: (request, exception) {
               capturedRequest = request;
-              capturedError = error;
+              capturedException = exception;
             },
           );
 
@@ -258,18 +258,18 @@ void main() {
 
           expect(capturedRequest?.method, equals('POST'));
           expect(capturedRequest?.url, equals(uri));
-          expect(capturedError, isA<SocketException>());
-          expect((capturedError as SocketException).message, equals('test error'));
+          expect(capturedException, isA<SocketException>());
+          expect((capturedException as SocketException).message, equals('test error'));
         });
 
-        test('onRequestError is not triggered for successful request', () async {
+        test('onRequestException is not triggered for successful request', () async {
           bool callbackTriggered = false;
 
           final inner = stubResult(statusCode: 200);
           final client = RestOfflineQueueClient(
             inner,
             requestManager,
-            onRequestError: (request, error) {
+            onRequestException: (request, exception) {
               callbackTriggered = true;
             },
           );

--- a/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
+++ b/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
@@ -201,9 +201,9 @@ abstract class OfflineFirstWithSupabaseRepository
         serialProcessing: serialProcessing,
       ),
       ignorePaths: ignorePaths,
-      reattemptForStatusCodes: reattemptForStatusCodes,
       onReattemptableResponse: onReattemptableResponse,
       onRequestError: onRequestError,
+      reattemptForStatusCodes: reattemptForStatusCodes,
     );
     return (client, RestOfflineRequestQueue(client: client));
   }

--- a/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
+++ b/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
@@ -190,7 +190,7 @@ abstract class OfflineFirstWithSupabaseRepository
     ],
     bool? serialProcessing,
     void Function(http.Request request, int statusCode)? onReattemptableResponse,
-    void Function(http.Request, Object)? onRequestError,
+    void Function(http.Request, Object)? onRequestException,
   }) {
     final client = RestOfflineQueueClient(
       innerClient ?? http.Client(),
@@ -202,7 +202,7 @@ abstract class OfflineFirstWithSupabaseRepository
       ),
       ignorePaths: ignorePaths,
       onReattemptableResponse: onReattemptableResponse,
-      onRequestError: onRequestError,
+      onRequestException: onRequestException,
       reattemptForStatusCodes: reattemptForStatusCodes,
     );
     return (client, RestOfflineRequestQueue(client: client));

--- a/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
+++ b/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
@@ -189,7 +189,7 @@ abstract class OfflineFirstWithSupabaseRepository
       504,
     ],
     bool? serialProcessing,
-    void Function(http.Request request, http.StreamedResponse response)? onReattemptableResponse,
+    void Function(http.Request request, int statusCode)? onReattemptableResponse,
     void Function(http.Request, Object)? onRequestError,
   }) {
     final client = RestOfflineQueueClient(

--- a/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
+++ b/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
@@ -189,7 +189,7 @@ abstract class OfflineFirstWithSupabaseRepository
       504,
     ],
     bool? serialProcessing,
-    void Function(http.Request request, int statusCode)? onReattemptableResponse,
+    void Function(http.Request request, int statusCode)? onReattempt,
     void Function(http.Request, Object)? onRequestException,
   }) {
     final client = RestOfflineQueueClient(
@@ -201,7 +201,7 @@ abstract class OfflineFirstWithSupabaseRepository
         serialProcessing: serialProcessing,
       ),
       ignorePaths: ignorePaths,
-      onReattemptableResponse: onReattemptableResponse,
+      onReattempt: onReattempt,
       onRequestException: onRequestException,
       reattemptForStatusCodes: reattemptForStatusCodes,
     );

--- a/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
+++ b/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
@@ -189,6 +189,9 @@ abstract class OfflineFirstWithSupabaseRepository
       504,
     ],
     bool? serialProcessing,
+    void Function(http.Request request, http.StreamedResponse response)?
+        onReattemptableResponse,
+    void Function(http.Request, Object)? onRequestError,
   }) {
     final client = RestOfflineQueueClient(
       innerClient ?? http.Client(),
@@ -200,6 +203,8 @@ abstract class OfflineFirstWithSupabaseRepository
       ),
       ignorePaths: ignorePaths,
       reattemptForStatusCodes: reattemptForStatusCodes,
+      onReattemptableResponse: onReattemptableResponse,
+      onRequestError: onRequestError,
     );
     return (client, RestOfflineRequestQueue(client: client));
   }

--- a/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
+++ b/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
@@ -189,8 +189,7 @@ abstract class OfflineFirstWithSupabaseRepository
       504,
     ],
     bool? serialProcessing,
-    void Function(http.Request request, http.StreamedResponse response)?
-        onReattemptableResponse,
+    void Function(http.Request request, http.StreamedResponse response)? onReattemptableResponse,
     void Function(http.Request, Object)? onRequestError,
   }) {
     final client = RestOfflineQueueClient(


### PR DESCRIPTION
This PR introduces two optional callbacks to the `RestOfflineQueueClient`, which closes https://github.com/GetDutchie/brick/issues/393.

1. `onReattemptableResponse`: This callback is invoked when a request returns a response with a status code listed in the reattemptForStatusCodes. It allows for detecting cases where a request is repeatedly rejected by the remote provider (e.g., when receiving an HTTP 409 (Conflict) response). When serial processing is enabled, this helps detect a blocked queue, allowing the app implementation to handle it appropriately.
2. `onRequestError`: This callback is triggered when a request throws an exception during execution (e.g., a SocketException). It helps identify the current state of the offline queue synchronization process.

In my application, these two callbacks are used to monitor the status of the offline queue, determining whether the queue is actively processing, blocked by a rejected request, or paused due to the client being offline. This allows me to provide users with real-time feedback on the system's sync status, which is important for my application.

@tshedor, what do you think of this implementation?

