### PR TITLE
Set policy for associations

### DIFF
--- a/packages/brick_offline_first/lib/src/offline_first_repository.dart
+++ b/packages/brick_offline_first/lib/src/offline_first_repository.dart
@@ -176,7 +176,9 @@ abstract class OfflineFirstRepository<TRepositoryModel extends OfflineFirstModel
   /// is ignorable (e.g. eager loading). Defaults to `false`.
   @override
   Future<List<TModel>> get<TModel extends TRepositoryModel>({
-    OfflineFirstGetPolicy policy = OfflineFirstGetPolicy.awaitRemoteWhenNoneExist,
+    OfflineFirstGetPolicy policy =
+        OfflineFirstGetPolicy.awaitRemoteWhenNoneExist,
+    OfflineFirstGetPolicy? policyForAssociations,
     Query? query,
     bool seedOnly = false,
   }) async {
@@ -189,7 +191,7 @@ abstract class OfflineFirstRepository<TRepositoryModel extends OfflineFirstModel
     final alwaysHydrate = policy == OfflineFirstGetPolicy.alwaysHydrate;
 
     try {
-      _latestGetPolicy = policy;
+      _latestGetPolicy = policyForAssociations ?? policy;
 
       if (memoryCacheProvider.canFind<TModel>(query) && !requireRemote) {
         final memoryCacheResults = memoryCacheProvider.get<TModel>(query: query, repository: this);
@@ -246,6 +248,7 @@ abstract class OfflineFirstRepository<TRepositoryModel extends OfflineFirstModel
   Future<List<TModel>> getBatched<TModel extends TRepositoryModel>({
     int batchSize = 50,
     OfflineFirstGetPolicy policy = OfflineFirstGetPolicy.awaitRemoteWhenNoneExist,
+    OfflineFirstGetPolicy? policyForAssociations,
     Query? query,
     bool seedOnly = false,
   }) async {
@@ -267,6 +270,7 @@ abstract class OfflineFirstRepository<TRepositoryModel extends OfflineFirstModel
       final results = await get<TModel>(
         query: recursiveQuery,
         policy: policy,
+        policyForAssociations: policyForAssociations,
         seedOnly: seedOnly,
       );
       total.addAll(results);
@@ -363,6 +367,7 @@ abstract class OfflineFirstRepository<TRepositoryModel extends OfflineFirstModel
   /// The stream will not close naturally.
   Stream<List<TModel>> subscribe<TModel extends TRepositoryModel>({
     OfflineFirstGetPolicy policy = OfflineFirstGetPolicy.localOnly,
+    OfflineFirstGetPolicy? policyForAssociations,
     Query? query,
   }) {
     query ??= const Query();
@@ -384,7 +389,10 @@ abstract class OfflineFirstRepository<TRepositoryModel extends OfflineFirstModel
     subscriptions[TModel]?[query] = controller;
 
     // ignore: discarded_futures
-    get<TModel>(query: query, policy: policy).then(
+    get<TModel>(
+            query: query,
+            policy: policy,
+            policyForAssociations: policyForAssociations,).then(
       (results) {
         if (!controller.isClosed) controller.add(results);
       },

--- a/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
+++ b/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
@@ -93,7 +93,9 @@ abstract class OfflineFirstWithSupabaseRepository<
 
   @override
   Future<List<TModel>> get<TModel extends TRepositoryModel>({
-    OfflineFirstGetPolicy policy = OfflineFirstGetPolicy.awaitRemoteWhenNoneExist,
+    OfflineFirstGetPolicy policy =
+        OfflineFirstGetPolicy.awaitRemoteWhenNoneExist,
+    OfflineFirstGetPolicy? policyForAssociations,
     Query? query,
     bool seedOnly = false,
   }) async {
@@ -259,6 +261,7 @@ abstract class OfflineFirstWithSupabaseRepository<
   Stream<List<TModel>> subscribeToRealtime<TModel extends TRepositoryModel>({
     PostgresChangeEvent eventType = PostgresChangeEvent.all,
     OfflineFirstGetPolicy policy = OfflineFirstGetPolicy.alwaysHydrate,
+    OfflineFirstGetPolicy? policyForAssociations,
     Query? query,
     String schema = 'public',
   }) {
@@ -291,7 +294,7 @@ abstract class OfflineFirstWithSupabaseRepository<
               case PostgresChangeEvent.all:
                 final localResults = await sqliteProvider.get<TModel>(repository: this);
                 final remoteResults =
-                    await get<TModel>(query: query, policy: OfflineFirstGetPolicy.awaitRemote);
+                    await get<TModel>(query: query, policy: OfflineFirstGetPolicy.awaitRemote, policyForAssociations: policyForAssociations);
                 final toDelete = localResults.where((r) => !remoteResults.contains(r));
 
                 for (final deletableModel in toDelete) {
@@ -310,6 +313,7 @@ abstract class OfflineFirstWithSupabaseRepository<
                 final results = await get<TModel>(
                   query: query,
                   policy: OfflineFirstGetPolicy.localOnly,
+                  policyForAssociations: policyForAssociations,
                   seedOnly: true,
                 );
                 if (results.isEmpty) return;
@@ -328,6 +332,7 @@ abstract class OfflineFirstWithSupabaseRepository<
                   await get<TModel>(
                     query: query,
                     policy: OfflineFirstGetPolicy.alwaysHydrate,
+                    policyForAssociations: policyForAssociations,
                     seedOnly: true,
                   );
 
@@ -370,7 +375,9 @@ abstract class OfflineFirstWithSupabaseRepository<
 
     // Fetch initial data
     // ignore: discarded_futures
-    get<TModel>(query: query, policy: policy).then((results) {
+    get<TModel>(query: query,
+        policy: policy,
+        policyForAssociations: policyForAssociations,).then((results) {
       if (!controller.isClosed) controller.add(results);
     });
 

--- a/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
+++ b/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
@@ -102,6 +102,7 @@ abstract class OfflineFirstWithSupabaseRepository<
     try {
       return await super.get<TModel>(
         policy: policy,
+        policyForAssociations: policyForAssociations,
         query: query,
         seedOnly: seedOnly,
       );


### PR DESCRIPTION
fixes #568 

Add an option to set the OfflineFirstGetPolicy for associations. As described before i experienced performance issues if i use alwaysHydrate with Model that have (nested) associations. So i added here an optional parameter to specify the policy for associations.