### PR TITLE
chore(offline_first_with_supabase): Catching AuthRetryableFetchException to ignore it on any action that does not have the remote policy

### DIFF
--- a/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
+++ b/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
@@ -82,13 +82,17 @@ abstract class OfflineFirstWithSupabaseRepository<
       return await super.delete<TModel>(instance, policy: policy, query: query);
     } on PostgrestException catch (e) {
       logger.warning('#delete supabase failure: $e');
-
       if (policy == OfflineFirstDeletePolicy.requireRemote) {
         throw OfflineFirstException(e);
       }
-
-      return false;
+    } on AuthRetryableFetchException catch (e) {
+      logger.warning('#delete supabase failure: $e');
+      if (policy == OfflineFirstDeletePolicy.requireRemote) {
+        throw OfflineFirstException(e);
+      }
     }
+
+    return false;
   }
 
   @override
@@ -105,13 +109,17 @@ abstract class OfflineFirstWithSupabaseRepository<
       );
     } on PostgrestException catch (e) {
       logger.warning('#get supabase failure: $e');
-
       if (policy == OfflineFirstGetPolicy.awaitRemote) {
         throw OfflineFirstException(e);
       }
-
-      return <TModel>[];
+    } on AuthRetryableFetchException catch (e) {
+      logger.warning('#get supabase failure: $e');
+      if (policy == OfflineFirstGetPolicy.awaitRemote) {
+        throw OfflineFirstException(e);
+      }
     }
+
+    return <TModel>[];
   }
 
   @protected
@@ -123,6 +131,8 @@ abstract class OfflineFirstWithSupabaseRepository<
     try {
       return await super.hydrate<TModel>(deserializeSqlite: deserializeSqlite, query: query);
     } on PostgrestException catch (e) {
+      logger.warning('#hydrate supabase failure: $e');
+    } on AuthRetryableFetchException catch (e) {
       logger.warning('#hydrate supabase failure: $e');
     }
 
@@ -387,13 +397,17 @@ abstract class OfflineFirstWithSupabaseRepository<
       return await super.upsert<TModel>(instance, policy: policy, query: query);
     } on PostgrestException catch (e) {
       logger.warning('#upsert supabase failure: $e');
-
       if (policy == OfflineFirstUpsertPolicy.requireRemote) {
         throw OfflineFirstException(e);
       }
-
-      return instance;
+    } on AuthRetryableFetchException catch (e) {
+      logger.warning('#upsert supabase failure: $e');
+      if (policy == OfflineFirstUpsertPolicy.requireRemote) {
+        throw OfflineFirstException(e);
+      }
     }
+
+    return instance;
   }
 
   PostgresChangeFilterType? _compareToFilterParam(Compare compare) {


### PR DESCRIPTION
Solution to issue https://github.com/GetDutchie/brick/issues/607 . Solving the following exception in OfflineFirst Supabase repositories:
```
I/flutter (18709): │ AuthRetryableFetchException(message: ClientException with SocketException: Connection refused (OS Error: Connection refused, errno = 111), address = 127.0.0.1, port = 35506, uri=http://127.0.0.1:54321/auth/v1/token?grant_type=refresh_token, statusCode: null)
```