### PR TITLE
fix: operationName attribute on Graphql Request Operation

### DIFF
--- a/packages/brick_graphql/lib/src/graphql_request.dart
+++ b/packages/brick_graphql/lib/src/graphql_request.dart
@@ -49,6 +49,7 @@ class GraphqlRequest<TModel extends GraphqlModel> {
     return Request(
       operation: Operation(
         document: defaultOperation.document,
+        operationName: defaultOperation.operationName,
       ),
       variables: requestVariables ?? {},
       context: context ?? const Context(),


### PR DESCRIPTION
**Fix GraphQL operationName Being Parsed as null for Offline Requests**

We noticed that the `operationName` on GraphQL `Request` `Operations` was being parsed as `null`. While this had no impact on online requests, it caused issues for offline requests where the `operationName` was stored as the string "null". When re-queued, the server responded with an error: `No operation named 'null'`.

To resolve this discrepancy, we now ensure that the `operationName` is correctly extracted from the GraphQL operation node itself, aligning both online and offline behaviour.