### PR TITLE
OfflineFirstDeletePolicy.localOnly

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,89 @@
 {
+  // Dart/Flutter specific settings
   "dart.lineLength": 100,
+  "dart.previewFlutterUiGuides": true,
+  "dart.previewFlutterUiGuidesCustomTracking": true,
+  "dart.insertArgumentPlaceholders": false,
+  "dart.debugSdkLibraries": false,
+  "dart.debugExternalPackageLibraries": false,
+  "dart.analysisExcludedFolders": [
+    "**/example/",
+    "example_rest/",
+    "example_graphql/",
+    "example_supabase/"
+  ],
+  // File handling
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "files.exclude": {
+    "**/.dart_tool/**": true,
+    "**/build/**": true,
+    "**/*.g.dart": true,
+    "**/*.iml": true
+  },
+  // Explorer settings for better project navigation
+  "explorer.fileNesting.enabled": true,
+  "explorer.fileNesting.expand": false,
+  "explorer.fileNesting.patterns": {
+    "pubspec.yaml": "pubspec.lock,analysis_options.yaml,.metadata",
+    "*.dart": "*.g.dart,*.freezed.dart",
+    "README.md": "CHANGELOG.md,LICENSE,CODEOWNERS"
+  },
+  // Editor formatting
   "editor.formatOnSave": true,
+  "editor.formatOnType": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": "explicit",
     "source.organizeImports": "explicit"
   },
-  "explorer.fileNesting.enabled": true,
-  "explorer.fileNesting.expand": false,
-  "files.insertFinalNewline": true
+  "editor.rulers": [
+    100
+  ],
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.detectIndentation": false,
+  // Language specific settings
+  "[dart]": {
+    "editor.formatOnSave": true,
+    "editor.formatOnType": true,
+    "editor.rulers": [
+      100
+    ],
+    "editor.selectionHighlight": false,
+    "editor.suggest.snippetsPreventQuickSuggestions": false,
+    "editor.suggestSelection": "first",
+    "editor.tabCompletion": "onlySnippets",
+    "editor.wordBasedSuggestions": "off"
+  },
+  "[yaml]": {
+    "editor.insertSpaces": true,
+    "editor.tabSize": 2,
+    "editor.autoIndent": "advanced"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "vscode.json-language-features"
+  },
+  "[markdown]": {
+    "editor.wordWrap": "wordWrapColumn",
+    "editor.wordWrapColumn": 80,
+    "editor.quickSuggestions": {
+      "comments": "off",
+      "strings": "off",
+      "other": "off"
+    },
+    "editor.suggest.showWords": false,
+    "editor.formatOnSave": false
+  },
+  // Search settings
+  "search.exclude": {
+    "**/.dart_tool/**": true,
+    "**/build/**": true,
+    "**/*.g.dart": true,
+    "**/node_modules/**": true,
+    "**/.git/**": true
+  },
+  // Workbench settings
+  "workbench.editorAssociations": {
+    "*.md": "default"
+  }
 }

--- a/docs/offline_first/policies.md
+++ b/docs/offline_first/policies.md
@@ -12,6 +12,10 @@ Delete local results before waiting for the remote provider to respond.
 
 Delete local results after remote responds; local results are not deleted if remote responds with any exception.
 
+### `localOnly`
+
+Delete local results only; do not send any request to the remote provider.
+
 ## OfflineFirstGetPolicy
 
 ### `alwaysHydrate`

--- a/packages/brick_offline_first/lib/src/offline_first_policy.dart
+++ b/packages/brick_offline_first/lib/src/offline_first_policy.dart
@@ -5,6 +5,9 @@ enum OfflineFirstDeletePolicy {
 
   /// Delete local results after remote responds; local results are not deleted if remote responds with any exception
   requireRemote,
+
+  /// Delete local results only; do not send any request to the remote provider
+  localOnly,
 }
 
 /// Data will **always** be returned from local providers and never directly

--- a/packages/brick_offline_first/test/offline_first/offline_first_repository_test.dart
+++ b/packages/brick_offline_first/test/offline_first/offline_first_repository_test.dart
@@ -52,6 +52,18 @@ void main() {
           throwsA(const TypeMatcher<SocketException>()),
         );
       });
+
+      test('OfflineFirstDeletePolicy.localOnly', () async {
+        final instance = Mounty(name: 'SqliteName');
+        final upserted = await TestRepository().upsert<Mounty>(instance);
+        expect(await TestRepository().sqliteProvider.get<Mounty>(), hasLength(1));
+        (TestRepository().remoteProvider as TestProvider).methodsCalled.clear();
+
+        await TestRepository().delete<Mounty>(upserted, policy: OfflineFirstDeletePolicy.localOnly);
+
+        expect(await TestRepository().sqliteProvider.get<Mounty>(), isEmpty);
+        expect((TestRepository().remoteProvider as TestProvider).methodsCalled, isEmpty);
+      });
     });
 
     group('#get', () {


### PR DESCRIPTION
Adds a new delete policy that removes records from local storage only, without hitting the remote API. Useful when you've changed data remotely through another mechanism and want to clean up local cache so the next query will sync fresh data.