### PR TITLE
chore(OfflineFirstGetPolicy): Added awaitRemoteAndOverwriteLocal

### DIFF
--- a/docs/offline_first/policies.md
+++ b/docs/offline_first/policies.md
@@ -1,6 +1,10 @@
 # Offline First Policies
 
-Repository methods can be invoked with policies to prioritize data sources. For example, a request may need to skip the offline queue or the response must come from a remote source. It is strongly encouraged to use a policy (e.g. `Repository().get<User>(policy: .requireRemote))`) instead of directly accessing a provider (e.g. `Repository().restPovider.get<User>()`).
+Repository methods can be invoked with policies to prioritize data sources. For
+example, a request may need to skip the offline queue or the response must come
+from a remote source. It is strongly encouraged to use a policy (e.g.
+`Repository().get<User>(policy: .requireRemote))`) instead of directly accessing
+a provider (e.g. `Repository().restPovider.get<User>()`).
 
 ## OfflineFirstDeletePolicy
 
@@ -10,21 +14,38 @@ Delete local results before waiting for the remote provider to respond.
 
 ### `requireRemote`
 
-Delete local results after remote responds; local results are not deleted if remote responds with any exception.
+Delete local results after remote responds; local results are not deleted if
+remote responds with any exception.
 
 ## OfflineFirstGetPolicy
 
 ### `alwaysHydrate`
 
-Ensures data is fetched from the remote provider(s) at each invocation. This hydration is unawaited and is not guaranteed to complete before results are returned. This can be expensive to perform for some queries; see [`awaitRemoteWhenNoneExist`](#awaitremotewhennoneexist) for a more performant option or [`awaitRemote`](#awaitremote) to await the hydration before returning results.
+Ensures data is fetched from the remote provider(s) at each invocation. This
+hydration is unawaited and is not guaranteed to complete before results are
+returned. This can be expensive to perform for some queries; see
+[`awaitRemoteWhenNoneExist`](#awaitremotewhennoneexist) for a more performant
+option or [`awaitRemote`](#awaitremote) to await the hydration before returning
+results.
 
 ### `awaitRemote`
 
-Ensures results must be updated from the remote proivder(s) before returning if the app is online. An empty array will be returned if the app is offline.
+Ensures results must be updated from the remote proivder(s) before returning if
+the app is online. An empty array will be returned if the app is offline.
+
+### `awaitRemoteAndOverwriteLocal`
+
+Ensures results must be updated from the remote provider(s) before returning if
+the app is online. After fetching from remote, any local data (SQLite and memory
+cache) that is not present in the remote results will be deleted to maintain
+consistency. This is useful when the remote data is the source of truth and
+local data should be kept in sync, such as after RPC function calls that modify
+data on the server. An empty array will be returned if the app is offline.
 
 ### `awaitRemoteWhenNoneExist` (default)
 
-Retrieves from the remote provider(s) if the query returns no results from the local provider(s).
+Retrieves from the remote provider(s) if the query returns no results from the
+local provider(s).
 
 ### `localOnly`
 
@@ -38,4 +59,5 @@ Save results to local before waiting for the remote provider to respond.
 
 ### `requireRemote`
 
-Save results to local after remote responds; local results are not saved if remote responds with any exception.
+Save results to local after remote responds; local results are not saved if
+remote responds with any exception.

--- a/packages/brick_offline_first/lib/src/offline_first_policy.dart
+++ b/packages/brick_offline_first/lib/src/offline_first_policy.dart
@@ -20,6 +20,12 @@ enum OfflineFirstGetPolicy {
   /// An empty array will be returned if the app is offline.
   awaitRemote,
 
+  /// Ensures results must be updated from the remote provider(s) before returning if the app is online.
+  /// After fetching from remote, any local data (SQLite and memory cache) that is not present
+  /// in the remote results will be deleted to maintain consistency.
+  /// An empty array will be returned if the app is offline.
+  awaitRemoteAndOverwriteLocal,
+
   /// Retrieves from the remote provider(s) if the query returns no results from the local provider(s).
   awaitRemoteWhenNoneExist,
 

--- a/packages/brick_offline_first/test/offline_first/offline_first_repository_test.dart
+++ b/packages/brick_offline_first/test/offline_first/offline_first_repository_test.dart
@@ -119,6 +119,28 @@ void main() {
 
         expect(results, isNotEmpty);
       });
+
+      test('OfflineFirstGetPolicy.awaitRemoteAndOverwriteLocal', () async {
+        final localMounty1 = Mounty(name: 'LocalMounty1');
+        final localMounty2 = Mounty(name: 'LocalMounty2');
+        await TestRepository().upsert<Mounty>(localMounty1);
+        await TestRepository().upsert<Mounty>(localMounty2);
+
+        final localResults =
+            await TestRepository().get<Mounty>(policy: OfflineFirstGetPolicy.localOnly);
+        expect(localResults, hasLength(2));
+
+        final results = await TestRepository()
+            .get<Mounty>(policy: OfflineFirstGetPolicy.awaitRemoteAndOverwriteLocal);
+
+        expect(results, hasLength(1));
+        expect(results.first.name, 'SqliteName');
+
+        final finalLocalResults =
+            await TestRepository().get<Mounty>(policy: OfflineFirstGetPolicy.localOnly);
+        expect(finalLocalResults, hasLength(1));
+        expect(finalLocalResults.first.name, 'SqliteName');
+      });
     });
 
     test(

--- a/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
+++ b/packages/brick_offline_first_with_rest/lib/src/offline_first_with_rest_repository.dart
@@ -141,7 +141,8 @@ abstract class OfflineFirstWithRestRepository<TRepositoryModel extends OfflineFi
       logger.warning('#get rest failure: $e');
 
       if (RestOfflineQueueClient.isATunnelNotFoundResponse(e.response) &&
-          policy != OfflineFirstGetPolicy.awaitRemote) {
+          policy != OfflineFirstGetPolicy.awaitRemote &&
+          policy != OfflineFirstGetPolicy.awaitRemoteAndOverwriteLocal) {
         return <TModel>[];
       }
 

--- a/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
+++ b/packages/brick_offline_first_with_supabase/lib/src/offline_first_with_supabase_repository.dart
@@ -109,12 +109,14 @@ abstract class OfflineFirstWithSupabaseRepository<
       );
     } on PostgrestException catch (e) {
       logger.warning('#get supabase failure: $e');
-      if (policy == OfflineFirstGetPolicy.awaitRemote) {
+      if (policy == OfflineFirstGetPolicy.awaitRemote ||
+          policy == OfflineFirstGetPolicy.awaitRemoteAndOverwriteLocal) {
         throw OfflineFirstException(e);
       }
     } on AuthRetryableFetchException catch (e) {
       logger.warning('#get supabase failure: $e');
-      if (policy == OfflineFirstGetPolicy.awaitRemote) {
+      if (policy == OfflineFirstGetPolicy.awaitRemote ||
+          policy == OfflineFirstGetPolicy.awaitRemoteAndOverwriteLocal) {
         throw OfflineFirstException(e);
       }
     }


### PR DESCRIPTION
`awaitRemoteAndOverwriteLocal` works as `awaitRemote` but removes local data that is no longer present in the remote.