### PR TITLE
Upgrading dependencies of brick_offline_first_with_supabase_build and all dependent packages

### DIFF
--- a/packages/brick_build/pubspec.yaml
+++ b/packages/brick_build/pubspec.yaml
@@ -4,21 +4,21 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_build
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=6.11.0 <8.0.0"
+  analyzer: ">=6.11.0 <9.0.0"
   brick_core: ">=2.0.0 <3.0.0"
-  build: ">=2.4.2 <2.5.0"
+  build: ">=2.4.2 <5.0.0"
   dart_style: ">=3.0.0 <4.0.0"
   glob: ">=2.1.0 <3.0.0"
   logging: ">=1.0.0 <2.0.0"
   meta: ">=1.3.0 <2.0.0"
   path: ">=1.9.0 <2.0.0"
-  source_gen: ">=1.5.0 <3.0.0"
+  source_gen: ">=1.5.0 <5.0.0"
 
 dev_dependencies:
   brick_build_test:

--- a/packages/brick_json_generators/pubspec.yaml
+++ b/packages/brick_json_generators/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_json_gene
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"
@@ -13,9 +13,9 @@ dependencies:
   analyzer: ">=6.11.0 <8.0.0"
   brick_build: ">=4.0.0 <5.0.0"
   brick_core: ">=2.0.0 <3.0.0"
-  build: ">=2.4.2 <2.5.0"
+  build: ">=2.4.2 <5.0.0"
   dart_style: ">=3.0.0 <4.0.0"
-  source_gen: ">=1.5.0 <3.0.0"
+  source_gen: ">=1.5.0 <5.0.0"
 
 dev_dependencies:
   brick_build_test:

--- a/packages/brick_offline_first_build/pubspec.yaml
+++ b/packages/brick_offline_first_build/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_offline_f
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"
@@ -17,12 +17,12 @@ dependencies:
   brick_offline_first: ">=4.0.0 <5.0.0"
   brick_sqlite: ">=4.0.0 <5.0.0"
   brick_sqlite_generators: ">=4.0.0 <5.0.0"
-  build: ">=2.4.2 <2.5.0"
+  build: ">=2.4.2 <5.0.0"
   dart_style: ">=3.0.0 <4.0.0"
   logging: ">=1.0.0 <2.0.0"
   meta: ">=1.3.0 <2.0.0"
   path: ">=1.9.0 <2.0.0"
-  source_gen: ">=1.5.0 <3.0.0"
+  source_gen: ">=1.5.0 <5.0.0"
 
 dev_dependencies:
   brick_build_test:

--- a/packages/brick_offline_first_with_supabase_build/pubspec.yaml
+++ b/packages/brick_offline_first_with_supabase_build/pubspec.yaml
@@ -4,13 +4,13 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_offline_f
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 2.0.0
+version: 2.0.1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"
 
 dependencies:
-  analyzer: ">=6.11.0 <8.0.0"
+  analyzer: ">=6.11.0 <9.0.0"
   brick_build: ">=4.0.0 <5.0.0"
   brick_offline_first: ">=4.0.0 <5.0.0"
   brick_offline_first_build: ">=4.0.0 <5.0.0"
@@ -19,12 +19,12 @@ dependencies:
   brick_sqlite_generators: ">=4.0.0 <5.0.0"
   brick_supabase: ">=2.0.0 <3.0.0"
   brick_supabase_generators: ">=2.0.0 <3.0.0"
-  build: ">=2.4.2 <2.5.0"
+  build: ">=2.4.2 <5.0.0"
   dart_style: ">=3.0.0 <4.0.0"
   logging: ">=1.0.0 <2.0.0"
   meta: ">=1.3.0 <2.0.0"
   path: ">=1.9.0 <2.0.0"
-  source_gen: ">=1.5.0 <3.0.0"
+  source_gen: ">=1.5.0 <5.0.0"
 
 dev_dependencies:
   brick_build_test:

--- a/packages/brick_rest_generators/pubspec.yaml
+++ b/packages/brick_rest_generators/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_rest_gene
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"
@@ -15,9 +15,9 @@ dependencies:
   brick_core: ">=2.0.0 <3.0.0"
   brick_json_generators: ">=4.0.0 <5.0.0"
   brick_rest: ">=4.0.0 <5.0.0"
-  build: ">=2.4.2 <2.5.0"
+  build: ">=2.4.2 <5.0.0"
   dart_style: ">=3.0.0 <4.0.0"
-  source_gen: ">=1.5.0 <3.0.0"
+  source_gen: ">=1.5.0 <5.0.0"
 
 dev_dependencies:
   brick_build_test:

--- a/packages/brick_sqlite_generators/pubspec.yaml
+++ b/packages/brick_sqlite_generators/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_sqlite_ge
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 4.0.1
+version: 4.0.2
 
 environment:
   sdk: ">=3.4.0 <4.0.0"
@@ -14,10 +14,10 @@ dependencies:
   brick_build: ">=4.0.0 <5.0.0"
   brick_core: ">=2.0.0 <4.0.0"
   brick_sqlite: ">=4.0.0 <5.0.0"
-  build: ">=2.4.2 <2.5.0"
+  build: ">=2.4.2 <5.0.0"
   dart_style: ">=3.0.0 <4.0.0"
   meta: ">=1.3.0 <2.0.0"
-  source_gen: ">=1.5.0 <3.0.0"
+  source_gen: ">=1.5.0 <5.0.0"
 
 dev_dependencies:
   brick_build_test:

--- a/packages/brick_supabase_generators/pubspec.yaml
+++ b/packages/brick_supabase_generators/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/GetDutchie/brick/tree/main/packages/brick_supabase_
 issue_tracker: https://github.com/GetDutchie/brick/issues
 repository: https://github.com/GetDutchie/brick
 
-version: 2.0.0
+version: 2.0.1
 
 environment:
   sdk: ">=3.4.0 <4.0.0"
@@ -15,9 +15,9 @@ dependencies:
   brick_core: ">=2.0.0 <3.0.0"
   brick_json_generators: ">=4.0.0 <5.0.0"
   brick_supabase: ">=2.0.0 <3.0.0"
-  build: ">=2.4.2 <2.5.0"
+  build: ">=2.4.2 <5.0.0"
   dart_style: ">=3.0.0 <4.0.0"
-  source_gen: ">=1.5.0 <3.0.0"
+  source_gen: ">=1.5.0 <5.0.0"
 
 dev_dependencies:
   brick_build_test:


### PR DESCRIPTION
The `build` and the `source_gen` dependency version ranges have been upgraded to encompass latest.
Needed in order to upgrade flutter and other 3rd party packages.

First time working with a monorepo, so I hope all is correct. I ran all the tests for each affected package.