### PR TITLE
fix(supabase): respect order by applying offset to computed query builder

### DIFF
--- a/packages/brick_supabase/lib/src/query_supabase_transformer.dart
+++ b/packages/brick_supabase/lib/src/query_supabase_transformer.dart
@@ -37,7 +37,7 @@ class QuerySupabaseTransformer<_Model extends SupabaseModel> {
 
     final offset = query?.offset;
     if (offset != null) {
-      final url = builder.overrideSearchParams('offset', (offset).toString());
+      final url = computedBuilder.overrideSearchParams('offset', (offset).toString());
       computedBuilder = computedBuilder.copyWithUrl(url);
     }
 


### PR DESCRIPTION
This fixes https://github.com/GetDutchie/brick/issues/645

The query builder was applying the offset to the unordered builder.