### PR TITLE
fix(build): Fix builder fail when model files have part directives

### DIFF
--- a/packages/brick_build/lib/src/builders/aggregate_builder.dart
+++ b/packages/brick_build/lib/src/builders/aggregate_builder.dart
@@ -67,9 +67,9 @@ class AggregateBuilder implements Builder {
         imports.addAll(findAllImports(contents));
         final newContents = contents
             .replaceAll(importRegex, '')
-            .replaceAll(RegExp("part of '.*';"), '')
-            .replaceAll(RegExp(r"^part\s'.*';", multiLine: true), '')
-            .replaceAll(RegExp(r'^export\s.*;', multiLine: true), '');
+            .replaceAll(RegExp(r'^\s*part(?: of)?\s+["\x27][^"\x27]*["\x27];', multiLine: true), '')
+            .replaceAll(RegExp(r'^\s*part\s+["\x27][^"\x27]*["\x27];', multiLine: true), '')
+            .replaceAll(RegExp(r'^\s*export\s+[^\n;]+;', multiLine: true), '');
         files.add(newContents);
       }
     }

--- a/packages/brick_build/lib/src/builders/aggregate_builder.dart
+++ b/packages/brick_build/lib/src/builders/aggregate_builder.dart
@@ -67,9 +67,9 @@ class AggregateBuilder implements Builder {
         imports.addAll(findAllImports(contents));
         final newContents = contents
             .replaceAll(importRegex, '')
-            .replaceAll(RegExp(r'^\s*part(?: of)?\s+["\x27][^"\x27]*["\x27];', multiLine: true), '')
-            .replaceAll(RegExp(r'^\s*part\s+["\x27][^"\x27]*["\x27];', multiLine: true), '')
-            .replaceAll(RegExp(r'^\s*export\s+[^\n;]+;', multiLine: true), '');
+            .replaceAll(RegExp(r'''^part of\s+["'][^"']+["'];''', multiLine: true), '')
+            .replaceAll(RegExp(r'''^part\s+["'][^"']+["'];''', multiLine: true), '')
+            .replaceAll(RegExp(r'^export\s+[^\n;]+;', multiLine: true), '');
         files.add(newContents);
       }
     }

--- a/packages/brick_build/lib/src/builders/model_dictionary_builder.dart
+++ b/packages/brick_build/lib/src/builders/model_dictionary_builder.dart
@@ -64,7 +64,11 @@ class ModelDictionaryBuilder<_ClassAnnotation> extends BaseBuilder<_ClassAnnotat
       {
         for (final annotation in annotations)
           '${annotation.element.name}': filesToContents.entries
-              .firstWhere((entry) => entry.value.contains(RegExp(r'class\s+${annotation.element.name}\s*')))
+              .firstWhere(
+                (entry) =>
+                    entry.key.endsWith('.model.dart') && // Only use model files
+                    entry.value.contains(RegExp('class\\s+${annotation.element.name}\\b')),
+              )
               .key
               // Make relative from the `brick/` folder
               .replaceAll(RegExp('^lib/'), '../'),


### PR DESCRIPTION
Related issue: #622 #547 

Fixed at least in my case I use double quotes in my model files, which skipped by the builder => part directives never get removed in final file.
This fixed by supporting regex with single quotes and double quotes