### PR TITLE
fix(build): fix missing type argument handling for non-generic typed lists (e.g. Uint8List)

### DIFF
--- a/packages/brick_build/lib/src/utils/shared_checker.dart
+++ b/packages/brick_build/lib/src/utils/shared_checker.dart
@@ -28,8 +28,18 @@ class SharedChecker<_SiblingModel extends Model> {
   /// the same domain or provider (e.g. `SqliteModel`).
   SharedChecker(this.targetType);
 
-  /// Retrieves type argument, i.e. `Type` in `Future<Type>` or `List<Type>`
-  DartType get argType => (targetType as InterfaceType).typeArguments.first;
+  /// Gets `T` from `List<T>` / `Future<T>`, or fallback for typed lists
+  DartType get argType {
+    final type = targetType as InterfaceType;
+    if (type.typeArguments.isNotEmpty) {
+      return type.typeArguments.first;
+    }
+    // Fallback for typed data lists
+    if (isList || isIterable) {
+      return type.element.library.typeProvider.intType;
+    }
+    throw StateError('No type argument for $targetType');
+  }
 
   ///
   Type get asPrimitive {
@@ -125,9 +135,9 @@ class SharedChecker<_SiblingModel extends Model> {
 
   ///
   bool get isIterable =>
-      _iterableChecker.isExactlyType(targetType) ||
-      _listChecker.isExactlyType(targetType) ||
-      _setChecker.isExactlyType(targetType);
+      _iterableChecker.isAssignableFromType(targetType) ||
+      _listChecker.isAssignableFromType(targetType) ||
+      _setChecker.isAssignableFromType(targetType);
 
   ///
   bool get isList => _listChecker.isExactlyType(targetType);


### PR DESCRIPTION
Related to my issue: https://github.com/GetDutchie/brick/issues/661#issuecomment-3756720139

Fix missing type argument handling for non-generic typed lists (e.g. `Uint8List`) in `argType`, ensuring a valid fallback type is returned instead of throwing.

---

Q: Why is Iterable assumed to be `int`?
A: Because `typed_data` collections in Dart do not preserve generics, and Brick needs a deterministic DB mapping for binary/typed buffers. `int` is the current storage representation.

If you don't agree, we can make a map like:
```dart
static final Map<String, DartType Function(TypeProvider)> _typeMap = {
  'Uint8List': (p) => p.intType,
  'Int8List': (p) => p.intType,
  'Int16List': (p) => p.intType,
  'Float32List': (p) => p.doubleType,
};
```
... instead of blindly assumed all as `intType`.